### PR TITLE
Move "acknowledgements" to be part of Markdown body 

### DIFF
--- a/src/component-queries/Diseases.tsx
+++ b/src/component-queries/Diseases.tsx
@@ -12,6 +12,7 @@ export interface QueryResult {
                     fields: {
                         slug: string;
                     };
+                    html: string;
                     frontmatter: DiseaseFrontmatter;
                 };
             }[];
@@ -32,13 +33,13 @@ const DiseaseTemplate = (props: QueryResult) => {
 
     const unpackedDiseases = diseases
         .map(({ node: disease }) => {
-            const { name, gene, acknowledgements, status } =
+            const { name, gene, status } =
                 disease.frontmatter;
             return {
                 name,
                 geneSymbol: gene.frontmatter.symbol,
                 geneName: gene.frontmatter.name,
-                acknowledgements,
+                acknowledgements: disease.html,
                 status,
             };
         })
@@ -74,11 +75,11 @@ export default function Diseases() {
                                 fields {
                                     slug
                                 }
+                                html
                                 frontmatter {
                                     templateKey
                                     name
                                     status
-                                    acknowledgements
                                     gene {
                                         frontmatter {
                                             symbol

--- a/src/components/DiseaseTable.tsx
+++ b/src/components/DiseaseTable.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { Table, Tag, Flex } from "antd";
 
-import Content from "./Content";
+import {HTMLContent} from "./Content";
 import { UnpackedDiseaseCellLine } from "../component-queries/DiseaseCellLines";
 import { formatCellLineId } from "../utils";
 
@@ -120,7 +120,7 @@ const DiseaseTable = ({
             dataSource={diseaseCellLines}
             footer={() => (
                 <div>
-                    <Content content={acknowledgements} />
+                    <HTMLContent content={acknowledgements} />
                 </div>
             )}
         />

--- a/src/components/DiseaseTable.tsx
+++ b/src/components/DiseaseTable.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { Table, Tag, Flex } from "antd";
 
-import {HTMLContent} from "./Content";
+import { HTMLContent } from "./Content";
 import { UnpackedDiseaseCellLine } from "../component-queries/DiseaseCellLines";
 import { formatCellLineId } from "../utils";
 

--- a/src/pages/diseases/cardiomyopathy-skeletal.md
+++ b/src/pages/diseases/cardiomyopathy-skeletal.md
@@ -3,7 +3,5 @@ templateKey: disease
 name: Skeletal Myopathy
 gene: MYH3
 status: Coming soon
-acknowledgements: These lines were generated at Allen Institute and released to
-  a group of collaborators to perform preliminary studies. We would like to
-  thank the following: David Mack, PhD, *University of Washington*
 ---
+These lines were generated at Allen Institute and released to a group of collaborators to perform preliminary studies. We would like to thank the following: David Mack, PhD, *University of Washington*

--- a/src/pages/diseases/cardiomyopathy.md
+++ b/src/pages/diseases/cardiomyopathy.md
@@ -2,11 +2,5 @@
 templateKey: disease
 name: Cardiomyopathy
 gene: MYH7
-acknowledgements: "These cell lines were generated at Allen Institute and
-  released to a group of collaborators to perform preliminary studies. We would
-  like to thank the following: Daniel Bernstein, MD, *Stanford University*, Soah
-  Lee, PhD, *Sungkyunkwan University*, Beth Pruitt, PhD, *University of
-  California*, Santa Barbara, Mike Regnier, PhD, *University of
-  Washington,* James Spudich, PhD, *Stanford University*, Sean Wu, MD, PhD,
-  *Stanford School of Medicine*"
 ---
+These cell lines were generated at Allen Institute and released to a group of collaborators to perform preliminary studies. We would like to thank the following: Daniel Bernstein, MD, *Stanford University*, Soah Lee, PhD, *Sungkyunkwan University*, Beth Pruitt, PhD, *University of California*, Santa Barbara, Mike Regnier, PhD, *University of Washington,* James Spudich, PhD, *Stanford University*, Sean Wu, MD, PhD, *Stanford School of Medicine*

--- a/src/pages/diseases/laminopathy.md
+++ b/src/pages/diseases/laminopathy.md
@@ -3,9 +3,5 @@ templateKey: disease
 name: Laminopathy
 gene: LMNA
 status: Available
-acknowledgements: These lines were generated at Allen Institute and released to
-  a group of collaborators to perform preliminary studies. We would like to
-  thank the following: Francis Collins, MD, PhD, NIH,  Michael Erdos, PhD, NIH,
-  Zhengmei Xiong, PhD, NIH, Abigail Buchwalter, PhD, *University of California,
-  San Francisco*
 ---
+These lines were generated at Allen Institute and released to a group of collaborators to perform preliminary studies. We would like to thank the following: Francis Collins, MD, PhD, NIH,  Michael Erdos, PhD, NIH, Zhengmei Xiong, PhD, NIH, Abigail Buchwalter, PhD, *University of California,San Francisco*

--- a/src/style/disease-table.module.css
+++ b/src/style/disease-table.module.css
@@ -83,6 +83,7 @@
 }
 
 .container :global(.ant-table-footer p) {
+    margin: 0;
     font-size: inherit;
     color: inherit;
 }

--- a/src/style/disease-table.module.css
+++ b/src/style/disease-table.module.css
@@ -82,6 +82,10 @@
     color: var(--LIGHT_BLUE);
 }
 
+.container :global(.ant-table-footer p) {
+    font-size: inherit;
+    color: inherit;
+}
 
 .container :global(.ant-table-cell .ant-tag) {
     color: var(--BLACK);

--- a/src/style/disease-table.module.css
+++ b/src/style/disease-table.module.css
@@ -77,15 +77,13 @@
     background-color: var(--OFF_WHITE);
     padding: 8px 0;
     border-radius: 0;
-    font-size: 14px;
     font-weight: 300;
-    color: var(--LIGHT_BLUE);
 }
 
 .container :global(.ant-table-footer p) {
     margin: 0;
-    font-size: inherit;
-    color: inherit;
+    font-size: 14px;
+    color: var(--LIGHT_BLUE);
 }
 
 .container :global(.ant-table-cell .ant-tag) {

--- a/static/admin/config.yml
+++ b/static/admin/config.yml
@@ -259,9 +259,9 @@ collections:
             }
           - {
                 label: "Acknowledgements",
-                name: "acknowledgements",
+                name: "body",
                 widget: "markdown",
-            }
+          }
     - name: "pages"
       label: "Pages"
       files:


### PR DESCRIPTION
Problem
=======
What is the problem this work solves, including
closes #12 

The issue is `acknowledgements` were not being rendered with Markdown formatting because the frontmatter stores metadata in yaml format.

Solution
========
What I/we did to solve this problem
- moved content within `acknowledgements` from frontmatter to the Markdown body
- refactored `DiseaseTable` and `DiseaseTemplate` components to query `acknowledgements` as `html` and render them using `HTMLContent`
- Tentatively adjusted css

## Type of change
Please delete options that are not relevant.
* Bug fix (non-breaking change which fixes an issue)


<img width="1730" alt="Screenshot 2024-03-11 at 11 06 50 AM" src="https://github.com/allen-cell-animated/cell-catalog/assets/91452427/b01bbdf9-b61c-4fc4-99ba-3b0c2a9097ce">


