### PR TITLE
add hover effects on "obtain line" and "cert. of analysis"

### DIFF
--- a/src/components/DiseaseTable.tsx
+++ b/src/components/DiseaseTable.tsx
@@ -17,6 +17,7 @@ const {
     clones,
     comingSoon,
     cloneNumber,
+    hoverColumn,
     footer,
 } = require("../style/disease-table.module.css");
 import { WHITE } from "./Layout";
@@ -120,6 +121,7 @@ const DiseaseTable = ({
                         title: "",
                         key: "order_link",
                         dataIndex: "order_link",
+                        className: hoverColumn,
                         render: (order_link) => {
                             if (inProgress) {
                                 return <>{""}</>; // still want a blank column
@@ -149,6 +151,7 @@ const DiseaseTable = ({
                         title: "",
                         key: "certificate_of_analysis",
                         dataIndex: "certificate_of_analysis",
+                        className: hoverColumn,
                         render: (certificate_of_analysis) => {
                             return (
                                 certificate_of_analysis && (

--- a/src/style/disease-table.module.css
+++ b/src/style/disease-table.module.css
@@ -45,6 +45,16 @@
     display: none; /* remove dividers between column headers */
 }
 
+.container :global(.ant-table-tbody > tr > td:nth-child(n+6):hover) {
+    background-color: var(--DARK_BLUE);
+}
+
+.container :global(.ant-table-tbody > tr > td:nth-child(n+6):hover) .action-button {
+    color: var(--WHITE);
+    fill: var(--WHITE);
+    stroke: var(--DARK_BLUE);
+}
+
 .container h4 {
     font-family: "Open Sans", sans-serif;
     font-size: 24px;

--- a/src/style/disease-table.module.css
+++ b/src/style/disease-table.module.css
@@ -51,8 +51,11 @@
 
 .container :global(.ant-table-tbody > tr > td:nth-child(n+6):hover) .action-button {
     color: var(--WHITE);
-    fill: var(--WHITE);
-    stroke: var(--DARK_BLUE);
+}
+
+.container :global(.ant-table-tbody > tr > td:nth-child(n+6):hover) .action-button path {
+    fill: var(--DARK_BLUE);
+    stroke: var(--WHITE);
 }
 
 .container h4 {

--- a/src/style/disease-table.module.css
+++ b/src/style/disease-table.module.css
@@ -45,15 +45,15 @@
     display: none; /* remove dividers between column headers */
 }
 
-.container :global(.ant-table-tbody > tr > td:nth-child(n+6):hover) {
+.container .hover-column:global(.ant-table-cell):has(a):hover {
     background-color: var(--DARK_BLUE);
 }
 
-.container :global(.ant-table-tbody > tr > td:nth-child(n+6):hover) .action-button {
+.hover-column:hover .action-button {
     color: var(--WHITE);
 }
 
-.container :global(.ant-table-tbody > tr > td:nth-child(n+6):hover) .action-button path {
+.hover-column:hover .action-button path {
     fill: var(--DARK_BLUE);
     stroke: var(--WHITE);
 }


### PR DESCRIPTION
Problem
=======
What is the problem this work solves, including
closes #27

Solution
========
What I/we did to solve this problem

- modified css to apply hover effects at the cell level for the last two columns 

Note: 

- The color toggle for the three little vertical strokes within the `Tube` icon isn't working. Should we make adjustments to the css or the svg?

- I noticed that our cert svg slightly differs from the one in the design, not sure if this is significant


## Type of change
Please delete options that are not relevant.
* New feature (non-breaking change which adds functionality)

Screenshots (optional):
-----------------------
<img width="1667" alt="Screenshot 2024-03-14 at 2 53 34 PM" src="https://github.com/allen-cell-animated/cell-catalog/assets/91452427/2cad6348-9d72-4480-aef5-dfee1ce9ed8d">



The `Cert.` icon in the design:
 
<img width="163" alt="Screenshot 2024-03-14 at 2 36 01 PM" src="https://github.com/allen-cell-animated/cell-catalog/assets/91452427/962b946b-cb91-4ce9-bd85-f914bcfc5a78">



