### PR TITLE
make disease a reference

### DIFF
--- a/src/pages/disease-cell-line/AICS-113/index.md
+++ b/src/pages/disease-cell-line/AICS-113/index.md
@@ -1,7 +1,7 @@
 ---
 templateKey: disease-cell-line
 cell_line_id: 113
-disease: Cardiomyopathy (Skeletal)
+disease: Skeletal Myopathy
 date: 2024-02-26T21:30:55.945Z
 snp: NM_0027470.4(MYH3):c.2306G>T(p.Gly769Val)
 parental_line: 75

--- a/static/admin/config.yml
+++ b/static/admin/config.yml
@@ -37,12 +37,7 @@ collections:
                 widget: "number",
                 required: true,
             }
-          - {
-                label: "name",
-                name: "name",
-                widget: "string",
-                required: false,
-            }
+          - { label: "name", name: "name", widget: "string", required: false }
           - {
                 label: "Status",
                 name: "status",
@@ -70,7 +65,7 @@ collections:
                 name: "parental_line",
                 widget: "number",
                 default: 0,
-                required: true
+                required: true,
             }
           - {
                 label: "Gene",
@@ -80,7 +75,7 @@ collections:
                 search_fields: ["symbol", "name", "protein", "structure"],
                 value_field: "symbol",
                 display_fields: ["symbol"],
-                required: false
+                required: false,
             }
           - {
                 label: "Allele Count",
@@ -145,13 +140,10 @@ collections:
           - {
                 label: "Disease",
                 name: "disease",
-                widget: "select",
-                options:
-                    [
-                        "Cardiomyopathy",
-                        "Cardiomyopathy (Skeletal)",
-                        "Laminopathy",
-                    ],
+                widget: "relation",
+                collection: "disease",
+                search_fields: ["name"],
+                value_field: "name",
             }
           - { label: "Publish Date", name: "date", widget: "datetime" }
           - { label: "SNP", name: "snp", widget: string }
@@ -171,11 +163,23 @@ collections:
                 default: "in progress",
                 required: true,
             }
-          - { label: "Clones", name: "clones", widget: object,
-              fields: [
-                  { label: "Number of mutant clones", name: "mutants", widget: number },
-                  { label: "Number of isogenic conrols", name: "isogenic_controls", widget: number },
-              ]
+          - {
+                label: "Clones",
+                name: "clones",
+                widget: object,
+                fields:
+                    [
+                        {
+                            label: "Number of mutant clones",
+                            name: "mutants",
+                            widget: number,
+                        },
+                        {
+                            label: "Number of isogenic conrols",
+                            name: "isogenic_controls",
+                            widget: number,
+                        },
+                    ],
             }
           - {
                 label: "Order Link",
@@ -327,7 +331,11 @@ collections:
                       fields:
                           [
                               { label: Heading, name: heading, widget: string },
-                              { label: Subheading, name: subheading, widget: string },
+                              {
+                                  label: Subheading,
+                                  name: subheading,
+                                  widget: string,
+                              },
 
                               {
                                   label: Description,


### PR DESCRIPTION
time: x-small

Problem
=======
the disease had changed name but the names were hardcoded in the dropdown of the cell lines

Solution
========
changed the dropdown to a relation 

verification: 
https://deploy-preview-35--cell-catalog.netlify.app/disease-catalog/ has all three diseases, while https://main--cell-catalog.netlify.app/disease-catalog/ only has two
