### PR TITLE
open order link in new window

### DIFF
--- a/src/components/DiseaseTable.tsx
+++ b/src/components/DiseaseTable.tsx
@@ -132,9 +132,11 @@ const DiseaseTable = ({
                             } else {
                                 return (
                                     <a
+                                        key={order_link}
                                         className={actionButton}
                                         href={order_link}
-                                        key={order_link}
+                                        target="_blank"
+                                        rel="noreferrer"
                                     >
                                         <Flex>
                                             <Icon
@@ -160,10 +162,11 @@ const DiseaseTable = ({
                             return (
                                 certificate_of_analysis && (
                                     <a
+                                        key={certificate_of_analysis.publicURL}
                                         className={actionButton}
                                         href={certificate_of_analysis.publicURL}
                                         target="_blank"
-                                        key={certificate_of_analysis.publicURL}
+                                        rel="noreferrer"
                                     >
                                         <Flex>
                                             <Icon


### PR DESCRIPTION
Problem
=======
The link to corriel doesn't link out, which ends up with corriel iframed in our site
https://allencellscience.slack.com/archives/C066Z582QJD/p1717176650138309

Solution
========
make the link open new window

## Type of change
Please delete options that are not relevant.

* Bug fix (non-breaking change which fixes an issue)

Verify:
-----------
https://deploy-preview-36--cell-catalog.netlify.app/disease-catalog/ click on obtain collection: should open new window


