### PR TITLE
Feature/mutation sites

### DIFF
--- a/static/admin/config.yml
+++ b/static/admin/config.yml
@@ -302,16 +302,18 @@ collections:
                 fields:
                     [
                         {
-                            label: "cRNA Target Site: enter PAM sites between square brackets like: AG[TGG]",
+                            label: "cRNA Target Site",
                             name: "crna_target_site",
                             widget: "string",
                             required: false,
+                            hint: "Enter entire cRNA Target Site sequence. Place square brackets around PAM site. e.g. AG[TGG]ATA",
                         },
                         {
                             label: "DNA Donor Sequence: enter mutation sites between square brackets like: AG[A]",
                             name: "dna_donor_sequence",
                             widget: "string",
                             required: false,
+                            hint: "Enter entire DNA donor sequence. Place square brackets around mutation sites. e.g. AG[A]AA",
                         },
                         {
                             label: "Cas9",

--- a/static/admin/config.yml
+++ b/static/admin/config.yml
@@ -309,7 +309,7 @@ collections:
                             hint: "Enter entire cRNA Target Site sequence. Place square brackets around PAM site. e.g. AG[TGG]ATA",
                         },
                         {
-                            label: "DNA Donor Sequence: enter mutation sites between square brackets like: AG[A]",
+                            label: "DNA Donor Sequence",
                             name: "dna_donor_sequence",
                             widget: "string",
                             required: false,

--- a/static/admin/config.yml
+++ b/static/admin/config.yml
@@ -302,13 +302,13 @@ collections:
                 fields:
                     [
                         {
-                            label: "cRNA Target Site",
+                            label: "cRNA Target Site: enter PAM sites between square brackets like: AG[TGG]",
                             name: "crna_target_site",
                             widget: "string",
                             required: false,
                         },
                         {
-                            label: "DNA Donor Sequence",
+                            label: "DNA Donor Sequence: enter mutation sites between square brackets like: AG[A]",
                             name: "dna_donor_sequence",
                             widget: "string",
                             required: false,


### PR DESCRIPTION
Adding some text to prompt scientists to mark PAM sites on cRNA Target Site, and mutation sites on DNA donor sequence with square brackets. We will parse these strings down the line to format those substrings.

Text and design reviewed by @TravisKroeker 