### PR TITLE
mobile adjustments

### DIFF
--- a/src/component-queries/DiseaseCellLines.tsx
+++ b/src/component-queries/DiseaseCellLines.tsx
@@ -16,6 +16,7 @@ export interface UnpackedDiseaseCellLine extends DiseaseCellLineFrontmatter {
     diseaseGene: JSX.Element | null;
     parentalLine: JSX.Element | null;
     path: string;
+    key: string;
 }
 
 const getParentalLineItems = (parentalLine: ParentalLineFrontmatter) => {
@@ -67,6 +68,7 @@ const groupLines = (
             path: cellLine.node.fields.slug,
             diseaseGene: null,
             parentalLine: null,
+            key: cellLine.node.id,
         };
         const diseaseData = diseases.find((d) => d.name === diseaseName);
         if (!diseaseData) {

--- a/src/components/DiseaseTable.tsx
+++ b/src/components/DiseaseTable.tsx
@@ -41,14 +41,11 @@ const DiseaseTable = ({
     const inProgress = status?.toLowerCase() === "coming soon";
 
     const useWindowWidth = () => {
-        const tabletBreakpoint = 768;
-        const [isMobile, setIsMobile] = useState(
-            window.innerWidth <= tabletBreakpoint
-        );
+        const [width, SetWidth] = useState(window.innerWidth);
 
         useEffect(() => {
             const handleResize = () => {
-                setIsMobile(window.innerWidth <= tabletBreakpoint);
+                SetWidth(window.innerWidth);
             };
             const debouncedHandleResize = debounce(handleResize, 200);
             window.addEventListener("resize", debouncedHandleResize);
@@ -56,10 +53,12 @@ const DiseaseTable = ({
                 window.removeEventListener("resize", debouncedHandleResize);
             };
         }, []);
-        return isMobile;
+        return width;
     };
 
-    const hasExpandableData = useWindowWidth();
+    const width = useWindowWidth();
+    const isTablet = width < 768;
+    const isMobile = width < 576;
     const renderCloneSummary = (
         numMutants: number,
         numIsogenics: number,
@@ -87,12 +86,28 @@ const DiseaseTable = ({
                 gap={16}
                 justify="flex-start"
                 className={expandableContent}
+                wrap={"wrap"}
             >
+                {isMobile && (
+                    <div>
+                        <label>SNP:</label>
+                        <Flex vertical={true} key={record.snp}>
+                            <span key={"snp-0"}>
+                                {record.snp.split(":")[0]}:{" "}
+                            </span>
+                            <span key={"snp-1"}>
+                                {record.snp.split(":")[1]}
+                            </span>
+                        </Flex>
+                    </div>
+                )}
                 <div>
                     <label>Gene Symbol & Name:</label>
-                    <span key={record.cell_line_id}>{record.diseaseGene}</span>
+                    <span>{record.diseaseGene}</span>
                 </div>
                 <div>
+                    <label>Clones:</label>
+
                     {renderCloneSummary(
                         getCloneSummary(record.clones).numMutants,
                         getCloneSummary(record.clones).numIsogenics,
@@ -118,7 +133,7 @@ const DiseaseTable = ({
                 )}
                 scroll={{ x: "max-content" }}
                 pagination={false}
-                expandable={hasExpandableData ? expandableConfig : undefined}
+                expandable={isTablet ? expandableConfig : undefined}
                 columns={[
                     {
                         title: "Cell Collection ID",
@@ -137,6 +152,7 @@ const DiseaseTable = ({
                         key: "snp",
                         dataIndex: "snp",
                         className: snpColumn,
+                        responsive: ["sm"],
                         render: (snp: string) => {
                             const snps = snp.split(":");
                             return (

--- a/src/components/DiseaseTable.tsx
+++ b/src/components/DiseaseTable.tsx
@@ -7,7 +7,6 @@ import { UnpackedDiseaseCellLine } from "../component-queries/DiseaseCellLines";
 import { formatCellLineId, getCloneSummary } from "../utils";
 import { WHITE } from "../style/theme";
 import { debounce } from "lodash";
-import exp from "constants";
 
 const Tube = require("../img/tube.svg");
 const CertificateIcon = require("../img/cert-icon.svg");

--- a/src/components/DiseaseTable.tsx
+++ b/src/components/DiseaseTable.tsx
@@ -41,6 +41,10 @@ const DiseaseTable = ({
     const inProgress = status?.toLowerCase() === "coming soon";
 
     const useWindowWidth = () => {
+        // so the build doesn't fail
+        if (typeof window === "undefined") {
+            return 0;
+        }
         const [width, SetWidth] = useState(window.innerWidth);
 
         useEffect(() => {

--- a/src/components/DiseaseTable.tsx
+++ b/src/components/DiseaseTable.tsx
@@ -6,7 +6,8 @@ import { HTMLContent } from "./shared/Content";
 import { UnpackedDiseaseCellLine } from "../component-queries/DiseaseCellLines";
 import { formatCellLineId, getCloneSummary } from "../utils";
 import { WHITE } from "../style/theme";
-import { debounce } from "lodash";
+import useWindowWidth from "../hooks/useWindowWidth";
+import { MOBILE_BREAKPOINT, TABLET_BREAKPOINT } from "../constants";
 
 const Tube = require("../img/tube.svg");
 const CertificateIcon = require("../img/cert-icon.svg");
@@ -40,29 +41,9 @@ const DiseaseTable = ({
 }: DiseaseTableProps) => {
     const inProgress = status?.toLowerCase() === "coming soon";
 
-    const useWindowWidth = () => {
-        // so the build doesn't fail
-        if (typeof window === "undefined") {
-            return 0;
-        }
-        const [width, SetWidth] = useState(window.innerWidth);
-
-        useEffect(() => {
-            const handleResize = () => {
-                SetWidth(window.innerWidth);
-            };
-            const debouncedHandleResize = debounce(handleResize, 200);
-            window.addEventListener("resize", debouncedHandleResize);
-            return () => {
-                window.removeEventListener("resize", debouncedHandleResize);
-            };
-        }, []);
-        return width;
-    };
-
     const width = useWindowWidth();
-    const isTablet = width < 768;
-    const isMobile = width < 576;
+    const isTablet = width < TABLET_BREAKPOINT;
+    const isMobile = width < MOBILE_BREAKPOINT;
     const renderCloneSummary = (
         numMutants: number,
         numIsogenics: number,

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,0 +1,2 @@
+export const TABLET_BREAKPOINT = 768;
+export const MOBILE_BREAKPOINT = 576;

--- a/src/hooks/useWindowWidth.ts
+++ b/src/hooks/useWindowWidth.ts
@@ -1,0 +1,24 @@
+import { debounce } from "lodash";
+import { useState, useEffect } from "react";
+
+const useWindowWidth = () => {
+    // so the build doesn't fail
+    if (typeof window === "undefined") {
+        return 0;
+    }
+    const [width, SetWidth] = useState(window.innerWidth);
+
+    useEffect(() => {
+        const handleResize = () => {
+            SetWidth(window.innerWidth);
+        };
+        const debouncedHandleResize = debounce(handleResize, 200);
+        window.addEventListener("resize", debouncedHandleResize);
+        return () => {
+            window.removeEventListener("resize", debouncedHandleResize);
+        };
+    }, []);
+    return width;
+};
+
+export default useWindowWidth;

--- a/src/style/constants.sass
+++ b/src/style/constants.sass
@@ -1,6 +1,0 @@
-/* Semantic color names */
-:root {
-    --mobile-breakpoint: 567px
-    --tablet-breakpoint: 768px
-}
-

--- a/src/style/constants.sass
+++ b/src/style/constants.sass
@@ -1,0 +1,6 @@
+/* Semantic color names */
+:root {
+    --mobile-breakpoint: 567px
+    --tablet-breakpoint: 768px
+}
+

--- a/src/style/disease-catalog.module.css
+++ b/src/style/disease-catalog.module.css
@@ -70,7 +70,7 @@
     font-weight: 300;
 }
 
-@media screen and (max-width: var(--tablet-breakpoint)) {
+@media screen and (max-width: 768px) {
     .header {
         flex-direction: column;
     }

--- a/src/style/disease-catalog.module.css
+++ b/src/style/disease-catalog.module.css
@@ -69,3 +69,9 @@
     color: var(--primary-color);
     font-weight: 300;
 }
+
+@media screen and (max-width: 768px) {
+    .header {
+        flex-direction: column;
+    }
+}

--- a/src/style/disease-catalog.module.css
+++ b/src/style/disease-catalog.module.css
@@ -70,7 +70,7 @@
     font-weight: 300;
 }
 
-@media screen and (max-width: 768px) {
+@media screen and (max-width: var(--tablet-breakpoint)) {
     .header {
         flex-direction: column;
     }

--- a/src/style/disease-table.module.css
+++ b/src/style/disease-table.module.css
@@ -33,7 +33,7 @@
 }
 
 .container :global(.ant-table-thead .ant-table-cell) {
-    padding: 10px 16px 10px 16px;
+    padding: 10px 16px;
     font-size: 14px;
     font-weight: 400;
     line-height: 34px;
@@ -65,7 +65,7 @@
     margin: 2px;
 }
 
-.container :global(.ant-table-cell) {
+.container :global(.ant-table-row .ant-table-cell) {
     vertical-align: middle;
     padding: 14px 16px;
 }
@@ -80,8 +80,8 @@
     text-wrap: balance;
 }
 
-.action-button {
-    max-width: 64px;
+.hover-column {
+    width: 160px;
 }
 
 .action-button a {
@@ -92,6 +92,7 @@
 .clones {
     text-wrap: balance;
     border-right: 1px solid var(--border-color);
+    min-width: 175px;
 }
 
 .clone-number {
@@ -141,4 +142,51 @@
 
 .container.coming-soon .clones {
     border-right: 1px solid transparent;
+}
+
+.container
+    :global(
+        .ant-table-cell.ant-table-row-expand-icon-cell.ant-table-cell-fix-left
+    ) {
+    width: 0px;
+    padding: 0px;
+}
+
+.expandable-content label {
+    font-size: 14px;
+    font-weight: 600;
+    color: var(--SERIOUS_GRAY);
+}
+
+@media screen and (max-width: 768px) {
+    .container h4 {
+        font-size: 20px;
+    }
+    .container :global(.ant-table-row .ant-table-cell),
+    .container :global(.ant-table-thead .ant-table-cell).cell-line-id,
+    .container :global(.ant-table-cell).cell-line-id {
+        padding: 8px 4px 8px 14px;
+    }
+}
+
+@media screen and (max-width: 576px) {
+    .container h4 {
+        font-size: 16px;
+    }
+    .container :global(.ant-table-row .ant-table-cell) {
+        padding-bottom: 4px;
+    }
+    .hover-column {
+        width: 120px;
+        padding: 4px !important;
+    }
+    .hover-column .action-button {
+        font-size: 14px;
+    }
+    .container
+        :global(
+            .ant-table-cell.ant-table-row-expand-icon-cell.ant-table-cell-fix-left
+        ) {
+        width: initial;
+    }
 }

--- a/src/style/disease-table.module.css
+++ b/src/style/disease-table.module.css
@@ -1,5 +1,4 @@
 @import "../style/colors.sass";
-@import "../style/constants.sass";
 
 .container {
     max-width: 1728px;

--- a/src/style/disease-table.module.css
+++ b/src/style/disease-table.module.css
@@ -153,9 +153,10 @@
 }
 
 .expandable-content label {
-    font-size: 14px;
+    font-size: 12px;
     font-weight: 600;
-    color: var(--SERIOUS_GRAY);
+    font-weight: 300;
+    color: var(--ALLEN_LIGHT_60);
 }
 
 @media screen and (max-width: 768px) {

--- a/src/style/disease-table.module.css
+++ b/src/style/disease-table.module.css
@@ -160,7 +160,7 @@
     color: var(--ALLEN_LIGHT_60);
 }
 
-@media screen and (max-width: var(--tablet-breakpoint)) {
+@media screen and (max-width: 768px) {
     .container h4 {
         font-size: 20px;
     }
@@ -171,7 +171,7 @@
     }
 }
 
-@media screen and (max-width: var(--mobile-breakpoint)) {
+@media screen and (max-width: 576px) {
     .container h4 {
         font-size: 16px;
     }

--- a/src/style/disease-table.module.css
+++ b/src/style/disease-table.module.css
@@ -1,4 +1,5 @@
 @import "../style/colors.sass";
+@import "../style/constants.sass";
 
 .container {
     max-width: 1728px;
@@ -159,7 +160,7 @@
     color: var(--ALLEN_LIGHT_60);
 }
 
-@media screen and (max-width: 768px) {
+@media screen and (max-width: var(--tablet-breakpoint)) {
     .container h4 {
         font-size: 20px;
     }
@@ -170,7 +171,7 @@
     }
 }
 
-@media screen and (max-width: 576px) {
+@media screen and (max-width: var(--mobile-breakpoint)) {
     .container h4 {
         font-size: 16px;
     }

--- a/src/style/index.sass
+++ b/src/style/index.sass
@@ -1,4 +1,3 @@
-
 body
     margin: 0
     width: 100%


### PR DESCRIPTION
Problem
=======
close #47 
NOTE: this doesn't have a design, it's the minimal amount of tweaks to just get it to not look terrible on smaller screens. In the future we'll have more fine tuning to do 

Solution
========
**tablets**: 
1. scroll when content gets too wide. 
2. Reduce padding

**mobile**: 
1. hide less critical columns
2. move some info into expandable content
4. reduce font size 

## Type of change

* New feature (non-breaking change which adds functionality)

Steps to Verify:
----------------
1. go to https://deploy-preview-63--cell-catalog.netlify.app/disease-catalog/
2. check the mobile view

Screenshots (optional):
-----------------------
Show-n-tell images/animations here

<img width="1230" alt="Screenshot 2024-09-27 at 12 45 40 PM" src="https://github.com/user-attachments/assets/d0bd456e-5dd5-484e-b2f1-9dfe1e93d4b8">

<img width="407" alt="Screenshot 2024-09-27 at 12 53 04 PM" src="https://github.com/user-attachments/assets/7e3f6c29-82b5-4b55-b3d9-4fc05bf24d40">
