### PR TITLE
add hover styles and onlick to main disease table row when hovering o…

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "author": "Austin Green",
   "dependencies": {
     "@ant-design/icons": "^5.5.1",
+    "@reach/router": "^1.3.4",
     "antd": "^5.21.2",
     "decap-cms-app": "^3.0.12",
     "decap-cms-media-library-cloudinary": "^3.0.1",

--- a/src/component-queries/DiseaseCellLines.tsx
+++ b/src/component-queries/DiseaseCellLines.tsx
@@ -76,7 +76,7 @@ const groupLines = (
         }
         cellLineData.diseaseGene = (
             <Flex wrap="wrap">
-                <Tag bordered={false} color="#F2F2F2">
+                <Tag bordered={false} color="#DFE5EA">
                     {diseaseData.geneSymbol}
                 </Tag>
                 <div>{diseaseData.geneName}</div>

--- a/src/components/DiseaseTable.tsx
+++ b/src/components/DiseaseTable.tsx
@@ -47,7 +47,6 @@ const DiseaseTable = ({
 }: DiseaseTableProps) => {
     const [hoveredRowIndex, setHoveredRowIndex] = useState(-1);
     const inProgress = status?.toLowerCase() === "coming soon";
-    const CELL_LINE_PATH = `/${diseaseCellLines[0].templateKey}/AICS-`;
 
     const width = useWindowWidth();
     const isTablet = width < TABLET_BREAKPOINT;
@@ -124,7 +123,7 @@ const DiseaseTable = ({
             onMouseLeave: () => setHoveredRowIndex(-1),
             onClick: () => {
                 if (record.status === CellLineStatus.DataComplete) {
-                    navigate(CELL_LINE_PATH + record.cell_line_id);
+                    navigate(record.path);
                 }
             },
         };
@@ -166,9 +165,7 @@ const DiseaseTable = ({
                             );
                             return record.status ===
                                 CellLineStatus.DataComplete ? (
-                                <Link to={CELL_LINE_PATH + cell_line_id}>
-                                    {cellLine}
-                                </Link>
+                                <Link to={record.path}>{cellLine}</Link>
                             ) : (
                                 cellLine
                             );

--- a/src/components/DiseaseTable.tsx
+++ b/src/components/DiseaseTable.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from "react";
+import { Link } from "gatsby";
 import { Table, Tag, Flex } from "antd";
 import Icon from "@ant-design/icons";
 
@@ -119,8 +120,10 @@ const DiseaseTable = ({
             onMouseEnter: () => setHoveredRowIndex(index),
             onMouseLeave: () => setHoveredRowIndex(-1),
             onClick: () => {
-                if (record.status === CellLineStatus.DataComplete)
+                if (record.status === CellLineStatus.DataComplete) {
+                    // if (true)
                     window.location.href = `/disease-cell-line/AICS-${record.cell_line_id}`;
+                }
             },
         };
     };
@@ -153,11 +156,20 @@ const DiseaseTable = ({
                         className: cellLineId,
                         dataIndex: "cell_line_id",
                         fixed: "left",
-                        render: (cell_line_id: string) => (
-                            <h4 key={cell_line_id}>
-                                {formatCellLineId(cell_line_id)}
-                            </h4>
-                        ),
+                        render: (cell_line_id, record) =>
+                            record.status === CellLineStatus.DataComplete ? (
+                                <Link
+                                    to={`/disease-cell-line/AICS-${cell_line_id}`}
+                                >
+                                    <h4 key={cell_line_id}>
+                                        {formatCellLineId(cell_line_id)}
+                                    </h4>
+                                </Link>
+                            ) : (
+                                <h4 key={cell_line_id}>
+                                    {formatCellLineId(cell_line_id)}
+                                </h4>
+                            ),
                         onCell: onCellInteraction,
                     },
                     {

--- a/src/components/DiseaseTable.tsx
+++ b/src/components/DiseaseTable.tsx
@@ -45,6 +45,7 @@ const DiseaseTable = ({
 }: DiseaseTableProps) => {
     const [hoveredRowIndex, setHoveredRowIndex] = useState(-1);
     const inProgress = status?.toLowerCase() === "coming soon";
+    const CELL_LINE_PATH = `/${diseaseCellLines[0].templateKey}/AICS-`;
 
     const width = useWindowWidth();
     const isTablet = width < TABLET_BREAKPOINT;
@@ -121,8 +122,7 @@ const DiseaseTable = ({
             onMouseLeave: () => setHoveredRowIndex(-1),
             onClick: () => {
                 if (record.status === CellLineStatus.DataComplete) {
-                    // if (true)
-                    window.location.href = `/disease-cell-line/AICS-${record.cell_line_id}`;
+                    window.location.href = CELL_LINE_PATH + record.cell_line_id;
                 }
             },
         };
@@ -156,20 +156,21 @@ const DiseaseTable = ({
                         className: cellLineId,
                         dataIndex: "cell_line_id",
                         fixed: "left",
-                        render: (cell_line_id, record) =>
-                            record.status === CellLineStatus.DataComplete ? (
-                                <Link
-                                    to={`/disease-cell-line/AICS-${cell_line_id}`}
-                                >
-                                    <h4 key={cell_line_id}>
-                                        {formatCellLineId(cell_line_id)}
-                                    </h4>
-                                </Link>
-                            ) : (
+                        render: (cell_line_id, record) => {
+                            const cellLine = (
                                 <h4 key={cell_line_id}>
                                     {formatCellLineId(cell_line_id)}
                                 </h4>
-                            ),
+                            );
+                            return record.status ===
+                                CellLineStatus.DataComplete ? (
+                                <Link to={CELL_LINE_PATH + cell_line_id}>
+                                    {cellLine}
+                                </Link>
+                            ) : (
+                                cellLine
+                            );
+                        },
                         onCell: onCellInteraction,
                     },
                     {

--- a/src/components/DiseaseTable.tsx
+++ b/src/components/DiseaseTable.tsx
@@ -2,6 +2,8 @@ import React, { useState } from "react";
 import { Link } from "gatsby";
 import { Table, Tag, Flex } from "antd";
 import Icon from "@ant-design/icons";
+// TODO: debug gatsby navigate throwing errors when passed strings
+import { navigate } from "@reach/router";
 
 import { HTMLContent } from "./shared/Content";
 import { UnpackedDiseaseCellLine } from "../component-queries/DiseaseCellLines";
@@ -122,7 +124,7 @@ const DiseaseTable = ({
             onMouseLeave: () => setHoveredRowIndex(-1),
             onClick: () => {
                 if (record.status === CellLineStatus.DataComplete) {
-                    window.location.href = CELL_LINE_PATH + record.cell_line_id;
+                    navigate(CELL_LINE_PATH + record.cell_line_id);
                 }
             },
         };

--- a/src/components/DiseaseTable.tsx
+++ b/src/components/DiseaseTable.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 import { Table, Tag, Flex } from "antd";
 import Icon from "@ant-design/icons";
 
@@ -24,6 +24,7 @@ const {
     clones,
     cellLineId,
     expandableContent,
+    hoveredRow,
 } = require("../style/disease-table.module.css");
 
 interface DiseaseTableProps {
@@ -39,6 +40,7 @@ const DiseaseTable = ({
     acknowledgements,
     status,
 }: DiseaseTableProps) => {
+    const [hoveredRowIndex, setHoveredRowIndex] = useState(-1);
     const inProgress = status?.toLowerCase() === "coming soon";
 
     const width = useWindowWidth();
@@ -103,6 +105,29 @@ const DiseaseTable = ({
         ),
     };
 
+    const handleCellInHoveredRow = (
+        record: UnpackedDiseaseCellLine,
+        index: number | undefined
+    ) => {
+        const hoveredAndDataComplete =
+            index === hoveredRowIndex && record.status === "data complete";
+        return {
+            className: hoveredAndDataComplete ? hoveredRow : "",
+            onMouseEnter: () => {
+                if (index !== undefined) {
+                    setHoveredRowIndex(index);
+                }
+            },
+            onMouseLeave: () => {
+                setHoveredRowIndex(-1);
+            },
+            onClick: () => {
+                if (hoveredAndDataComplete)
+                    window.location.href = `/disease-cell-line/AICS-${record.cell_line_id}`;
+            },
+        };
+    };
+
     return (
         <>
             <Table
@@ -131,6 +156,7 @@ const DiseaseTable = ({
                                 {formatCellLineId(cell_line_id)}
                             </h4>
                         ),
+                        onCell: handleCellInHoveredRow,
                     },
                     {
                         title: "SNP",
@@ -147,6 +173,7 @@ const DiseaseTable = ({
                                 </Flex>
                             );
                         },
+                        onCell: handleCellInHoveredRow,
                     },
                     {
                         title: "Gene Symbol & Name",
@@ -154,12 +181,14 @@ const DiseaseTable = ({
                         key: "diseaseGene",
                         dataIndex: "diseaseGene",
                         responsive: ["md"],
+                        onCell: handleCellInHoveredRow,
                     },
                     {
                         title: "Parental Line",
                         key: "parentalLine",
                         dataIndex: "parentalLine",
                         responsive: ["md"],
+                        onCell: handleCellInHoveredRow,
                     },
                     {
                         title: "Clones",
@@ -177,6 +206,7 @@ const DiseaseTable = ({
                                 index
                             );
                         },
+                        onCell: handleCellInHoveredRow,
                     },
                     {
                         title: "",

--- a/src/components/DiseaseTable.tsx
+++ b/src/components/DiseaseTable.tsx
@@ -4,6 +4,7 @@ import Icon from "@ant-design/icons";
 
 import { HTMLContent } from "./shared/Content";
 import { UnpackedDiseaseCellLine } from "../component-queries/DiseaseCellLines";
+import { CellLineStatus } from "../component-queries/types";
 import { formatCellLineId, getCloneSummary } from "../utils";
 import { WHITE } from "../style/theme";
 import useWindowWidth from "../hooks/useWindowWidth";
@@ -19,12 +20,13 @@ const {
     actionButton,
     comingSoon,
     cloneNumber,
-    hoverColumn,
+    actionColumn,
     footer,
     clones,
     cellLineId,
     expandableContent,
     hoveredRow,
+    dataComplete,
 } = require("../style/disease-table.module.css");
 
 interface DiseaseTableProps {
@@ -105,24 +107,19 @@ const DiseaseTable = ({
         ),
     };
 
-    const handleCellInHoveredRow = (
+    const onCellInteraction = (
         record: UnpackedDiseaseCellLine,
         index: number | undefined
     ) => {
-        const hoveredAndDataComplete =
-            index === hoveredRowIndex && record.status === "data complete";
+        if (index === undefined) {
+            return {};
+        }
         return {
-            className: hoveredAndDataComplete ? hoveredRow : "",
-            onMouseEnter: () => {
-                if (index !== undefined) {
-                    setHoveredRowIndex(index);
-                }
-            },
-            onMouseLeave: () => {
-                setHoveredRowIndex(-1);
-            },
+            className: index === hoveredRowIndex ? hoveredRow : "",
+            onMouseEnter: () => setHoveredRowIndex(index),
+            onMouseLeave: () => setHoveredRowIndex(-1),
             onClick: () => {
-                if (hoveredAndDataComplete)
+                if (record.status === CellLineStatus.DataComplete)
                     window.location.href = `/disease-cell-line/AICS-${record.cell_line_id}`;
             },
         };
@@ -133,6 +130,11 @@ const DiseaseTable = ({
             <Table
                 key={diseaseName}
                 className={[container, inProgress ? comingSoon : ""].join(" ")}
+                rowClassName={(record) =>
+                    record.status === CellLineStatus.DataComplete
+                        ? dataComplete
+                        : ""
+                }
                 title={() => (
                     <Flex align="center">
                         <h3 className={tableTitle}>{diseaseName}</h3>
@@ -156,7 +158,7 @@ const DiseaseTable = ({
                                 {formatCellLineId(cell_line_id)}
                             </h4>
                         ),
-                        onCell: handleCellInHoveredRow,
+                        onCell: onCellInteraction,
                     },
                     {
                         title: "SNP",
@@ -173,7 +175,7 @@ const DiseaseTable = ({
                                 </Flex>
                             );
                         },
-                        onCell: handleCellInHoveredRow,
+                        onCell: onCellInteraction,
                     },
                     {
                         title: "Gene Symbol & Name",
@@ -181,14 +183,14 @@ const DiseaseTable = ({
                         key: "diseaseGene",
                         dataIndex: "diseaseGene",
                         responsive: ["md"],
-                        onCell: handleCellInHoveredRow,
+                        onCell: onCellInteraction,
                     },
                     {
                         title: "Parental Line",
                         key: "parentalLine",
                         dataIndex: "parentalLine",
                         responsive: ["md"],
-                        onCell: handleCellInHoveredRow,
+                        onCell: onCellInteraction,
                     },
                     {
                         title: "Clones",
@@ -206,13 +208,13 @@ const DiseaseTable = ({
                                 index
                             );
                         },
-                        onCell: handleCellInHoveredRow,
+                        onCell: onCellInteraction,
                     },
                     {
                         title: "",
                         key: "order_link",
                         dataIndex: "order_link",
-                        className: hoverColumn,
+                        className: actionColumn,
                         fixed: "right",
                         render: (order_link) => {
                             if (inProgress) {
@@ -245,7 +247,7 @@ const DiseaseTable = ({
                         title: "",
                         key: "certificate_of_analysis",
                         dataIndex: "certificate_of_analysis",
-                        className: hoverColumn,
+                        className: actionColumn,
                         fixed: "right",
                         responsive: ["md"],
                         render: (certificate_of_analysis) => {

--- a/src/components/ParentalLineModal.tsx
+++ b/src/components/ParentalLineModal.tsx
@@ -23,11 +23,13 @@ interface ParentalLineModalProps {
 }
 const ParentalLineModal = (props: ParentalLineModalProps) => {
     const [isModalOpen, setIsModalOpen] = useState(false);
-    const showModal = () => {
+    const showModal = (e: React.MouseEvent<HTMLElement, MouseEvent>) => {
+        e.stopPropagation();
         setIsModalOpen(true);
     };
 
-    const handleCancel = () => {
+    const handleCancel = (e: React.MouseEvent<HTMLButtonElement>) => {
+        e.stopPropagation();
         setIsModalOpen(false);
     };
     const image = getImage(props.image);
@@ -41,13 +43,13 @@ const ParentalLineModal = (props: ParentalLineModalProps) => {
     );
     return (
         <>
-            <Button onClick={showModal}>
+            <Button onClick={(e) => showModal(e)}>
                 {props.cellLineId} {<InfoCircleOutlined />}
             </Button>
             <Modal
                 title={headerElement}
                 open={isModalOpen}
-                onCancel={handleCancel}
+                onCancel={(e) => handleCancel(e)}
                 width={555}
                 centered={true}
                 className={modal}

--- a/src/style/disease-table.module.css
+++ b/src/style/disease-table.module.css
@@ -49,6 +49,10 @@
     cursor: pointer;
 }
 
+.container .data-complete .hovered-row:global(.ant-table-cell) h4 {
+    text-decoration: underline;
+}
+
 .container .action-column:global(.ant-table-cell):has(a):hover {
     background-color: var(--primary-color);
 }
@@ -125,8 +129,13 @@
 }
 
 .container :global(.ant-table-cell .ant-btn) {
+    background-color: var(--WHITE);
     font-weight: 600;
     font-size: 16px;
+}
+
+.container .data-complete .hovered-row:global(.ant-table-cell .ant-btn) {
+    background-color: var(--ALLEN_LIGHT_10);
 }
 
 .container :global(.ant-table-title .ant-tag) {

--- a/src/style/disease-table.module.css
+++ b/src/style/disease-table.module.css
@@ -44,20 +44,20 @@
     display: none; /* remove dividers between column headers */
 }
 
-.container :global(.ant-table-row) .hovered-row:global(.ant-table-cell) {
+.container .data-complete .hovered-row:global(.ant-table-cell) {
     background-color: var(--ALLEN_LIGHT_10);
     cursor: pointer;
 }
 
-.container .hover-column:global(.ant-table-cell):has(a):hover {
+.container .action-column:global(.ant-table-cell):has(a):hover {
     background-color: var(--primary-color);
 }
 
-.hover-column:hover .action-button {
+.action-column:hover .action-button {
     color: var(--WHITE);
 }
 
-.hover-column:hover .action-button path {
+.action-column:hover .action-button path {
     fill: var(--primary-color);
     stroke: var(--WHITE);
 }
@@ -85,7 +85,7 @@
     text-wrap: balance;
 }
 
-.hover-column {
+.action-column {
     width: 160px;
 }
 
@@ -182,11 +182,11 @@
     .container :global(.ant-table-row .ant-table-cell) {
         padding-bottom: 4px;
     }
-    .hover-column {
+    .action-column {
         width: 120px;
         padding: 4px !important;
     }
-    .hover-column .action-button {
+    .action-column .action-button {
         font-size: 14px;
     }
     .container

--- a/src/style/disease-table.module.css
+++ b/src/style/disease-table.module.css
@@ -44,6 +44,11 @@
     display: none; /* remove dividers between column headers */
 }
 
+.container :global(.ant-table-row) .hovered-row:global(.ant-table-cell) {
+    background-color: var(--ALLEN_LIGHT_10);
+    cursor: pointer;
+}
+
 .container .hover-column:global(.ant-table-cell):has(a):hover {
     background-color: var(--primary-color);
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3234,6 +3234,16 @@
     rc-resize-observer "^1.3.1"
     rc-util "^5.38.0"
 
+"@reach/router@^1.3.4":
+  version "1.3.4"
+  resolved "https://registry.yarnpkg.com/@reach/router/-/router-1.3.4.tgz#d2574b19370a70c80480ed91f3da840136d10f8c"
+  integrity sha512-+mtn9wjlB9NN2CNnnC/BRYtwdKBfSyyasPYraNAyvaV1occr/5NnB4CVzjEZipNHwYebQwcndGUmpFzxAUoqSA==
+  dependencies:
+    create-react-context "0.3.0"
+    invariant "^2.2.3"
+    prop-types "^15.6.1"
+    react-lifecycles-compat "^3.0.4"
+
 "@react-dnd/asap@^4.0.0":
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/@react-dnd/asap/-/asap-4.0.1.tgz#5291850a6b58ce6f2da25352a64f1b0674871aab"
@@ -6525,6 +6535,14 @@ create-react-class@^15.5.1:
   dependencies:
     loose-envify "^1.3.1"
     object-assign "^4.1.1"
+
+create-react-context@0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/create-react-context/-/create-react-context-0.3.0.tgz#546dede9dc422def0d3fc2fe03afe0bc0f4f7d8c"
+  integrity sha512-dNldIoSuNSvlTJ7slIKC/ZFGKexBMBrrcc+TTe1NdmROnaASuLPvqpwj9v4XS4uXZ8+YPu0sNmShX2rXI5LNsw==
+  dependencies:
+    gud "^1.0.0"
+    warning "^4.0.3"
 
 create-require@^1.1.0:
   version "1.1.1"
@@ -10178,6 +10196,11 @@ gray-matter@^4.0.2, gray-matter@^4.0.3:
     section-matter "^1.0.0"
     strip-bom-string "^1.0.0"
 
+gud@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/gud/-/gud-1.0.0.tgz#a489581b17e6a70beca9abe3ae57de7a499852c0"
+  integrity sha512-zGEOVKFM5sVPPrYs7J5/hYEw2Pof8KCyOwyhG8sAF26mCAeUFAcYPu1mwB7hhpIP29zOIBaDqwuHdLp0jvZXjw==
+
 gzip-size@^6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/gzip-size/-/gzip-size-6.0.0.tgz#065367fd50c239c0671cbcbad5be3e2eeb10e462"
@@ -10876,7 +10899,7 @@ internal-slot@^1.0.5:
     hasown "^2.0.0"
     side-channel "^1.0.4"
 
-invariant@^2.0.0, invariant@^2.2.2, invariant@^2.2.4:
+invariant@^2.0.0, invariant@^2.2.2, invariant@^2.2.3, invariant@^2.2.4:
   version "2.2.4"
   resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.4.tgz#610f3c92c9359ce1db616e538008d23ff35158e6"
   integrity sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==
@@ -14961,7 +14984,7 @@ prompts@^2.4.2:
     kleur "^3.0.3"
     sisteransi "^1.0.5"
 
-prop-types@^15.0.0, prop-types@^15.5.10, prop-types@^15.5.4, prop-types@^15.5.6, prop-types@^15.5.7, prop-types@^15.5.8, prop-types@^15.6.0, prop-types@^15.6.2, prop-types@^15.7.2, prop-types@^15.8.1:
+prop-types@^15.0.0, prop-types@^15.5.10, prop-types@^15.5.4, prop-types@^15.5.6, prop-types@^15.5.7, prop-types@^15.5.8, prop-types@^15.6.0, prop-types@^15.6.1, prop-types@^15.6.2, prop-types@^15.7.2, prop-types@^15.8.1:
   version "15.8.1"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.8.1.tgz#67d87bf1a694f48435cf332c24af10214a3140b5"
   integrity sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==


### PR DESCRIPTION
Closes #67 

Merging blocked.

Problem
=======
This adds hover styling and `onClick` navigation to disease table rows when they have complete data.

Event propagation is blocked in `ParentalLineModal `so that modal can be opened and closed without triggering the parent row's `onClick`.

My understanding is that this should only be functional if the status of the disease line is `"data complete"`, which isn't true for the disease lines currently, so the merged changes will not seem functional. 

To see the hover states and make links functional, replace `record.status === CellLineStatus.DataComplete` on L126 and L139 with `true`