### PR TITLE
add style

### DIFF
--- a/src/style/main-card.module.css
+++ b/src/style/main-card.module.css
@@ -34,6 +34,8 @@
     border: 2.5px solid var(--primary-color);
     margin-top: 16px;
     background-color: var(--ALLEN_LIGHT_10);
+    display: flex;
+    flex-direction: column;
 }
 
 .extra-large-button h2 {


### PR DESCRIPTION
Problem
=======
the big button broke
<img width="513" alt="Screenshot 2024-10-15 at 4 24 30 PM" src="https://github.com/user-attachments/assets/7139391b-5ce2-4128-8325-73369494ae04">
I'm not sure how, it might have been a mistake in a merge conflict 

Solution
========
added flex styling 

## Type of change
Please delete options that are not relevant.

* Bug fix (non-breaking change which fixes an issue)

Screenshots (optional):
-----------------------
<img width="536" alt="Screenshot 2024-10-15 at 4 23 52 PM" src="https://github.com/user-attachments/assets/abf93253-6ae3-47d8-bc3b-9d46c8339a5c">
