### PR TITLE
add and render clone data

### DIFF
--- a/src/components/CloneTable.tsx
+++ b/src/components/CloneTable.tsx
@@ -11,7 +11,7 @@ interface CloneTableProps {
 const CloneTable: React.FC<CloneTableProps> = ({ dataSource }) => {
     // NOTE: once the clone data is filled in, we can use the id as the key
     const dataSourceWithKey = dataSource.map((data, index) => {
-        return { ...data, key: index };
+        return { ...data, clone_number: `cl.${data.clone_number}`, key: index };
     });
     const cloneTableColumns = [
         {

--- a/src/templates/disease-cell-line.tsx
+++ b/src/templates/disease-cell-line.tsx
@@ -268,7 +268,10 @@ export const pageQuery = graphql`
                 }
                 snp
                 clones {
+                    clone_number
                     type
+                    transfection_replicate
+                    genotype
                 }
                 certificate_of_analysis
                 order_link


### PR DESCRIPTION
Problem
=======
What is the problem this work solves, including
The clone table currently displays only the `Clone Type` column. 


Solution
========
What I/we did to solve this problem
Added the rest of clone data

## Type of change
Please delete options that are not relevant.
* New feature (non-breaking change which adds functionality)

Screenshots (optional):
-----------------------
<img width="300" alt="Screenshot 2024-10-25 at 12 53 08 PM" src="https://github.com/user-attachments/assets/f760a90e-05ec-4452-a98e-89cdec68f08d">
