### PR TITLE
add image modal

### DIFF
--- a/src/components/ImagesAndVideos.tsx
+++ b/src/components/ImagesAndVideos.tsx
@@ -1,6 +1,6 @@
 import { Card, Flex } from "antd";
 import { getImage, GatsbyImage } from "gatsby-plugin-image";
-import React from "react";
+import React, { useState } from "react";
 import { ParentalLineFrontmatter } from "../component-queries/types";
 import { formatCellLineId } from "../utils";
 const {
@@ -12,6 +12,10 @@ const {
     imageSection,
     caption,
     imageContainer,
+    thumbnail,
+    modal,
+    modalContent,
+    close,
 } = require("../style/images-and-videos.module.css");
 
 interface ImagesAndVideosProps {
@@ -29,6 +33,7 @@ const ImagesAndVideos: React.FC<ImagesAndVideosProps> = ({
     parentalLine,
     geneSymbol,
 }) => {
+    const [isModalOpen, setModalOpen] = useState(false);
     const mainImage = images.length > 0 ? images[0] : null;
     const imageData = mainImage ? getImage(mainImage.image) : null;
     const fluorescentTag = parentalLine.fluorescent_tag;
@@ -51,6 +56,15 @@ const ImagesAndVideos: React.FC<ImagesAndVideosProps> = ({
         </Flex>
     );
 
+
+    const showModal = () => {
+        setModalOpen(true);
+    };
+
+    const closeModal = () => {
+        setModalOpen(false);
+    };
+
     return (
         <Card className={container} title={title} style={{ width: "100%" }}>
             <Flex
@@ -60,12 +74,19 @@ const ImagesAndVideos: React.FC<ImagesAndVideosProps> = ({
                 className={imageSection}
             >
                 {imageData && (
-                    <div className={imageContainer}>
+                    <div className={`${imageContainer} ${thumbnail}`} onClick={showModal}>
                         <GatsbyImage image={imageData} alt="main image"></GatsbyImage>
                     </div>
                 )}
                 {mainImage?.caption && <p className={caption}>{mainImage.caption}</p>}
             </Flex>
+
+            { isModalOpen && imageData && (
+                    <div className={modal} onClick={closeModal}>
+                        <span className={close}>&times;</span>
+                        <GatsbyImage className={modalContent} image={imageData} alt="full image"></GatsbyImage>
+                    </div>
+            )}
         </Card>
     );
 };

--- a/src/style/images-and-videos.module.css
+++ b/src/style/images-and-videos.module.css
@@ -51,3 +51,36 @@
     font-size: 12px;
     padding: 8px 80px;
 }
+
+.thumbnail {
+    max-width: 545px;
+    max-height: 545px;
+    overflow: hidden;
+    cursor: pointer;
+    width: 100%;
+}
+
+.modal {
+    display: flex;
+    justify-content: center;
+    background-color: var(--WHITE);
+    position: fixed;
+    left: 0;
+    top: 0;
+    width: 70%;
+    height: 80%;
+    padding-bottom: 20px;
+}
+
+.modal-content {
+    max-width: 100%;
+    max-height: 100%;
+    margin: auto;
+}
+
+.close {
+    position: absolute;
+    top: 20px;
+    right: 35px;
+    cursor: pointer;
+}


### PR DESCRIPTION
Problem
=======
What is the problem this work solves, including
closes #76 

Solution
========
What I/we did to solve this problem
- images larger than the container's max width and length are scaled down to fit within the container 
- clicking on an image will open a modal displaying the image in full size 

with @TravisKroeker 

## Type of change
Please delete options that are not relevant.
* New feature (non-breaking change which adds functionality)
