### PR TITLE
Allow multiple genes entry for normal cell lines

### DIFF
--- a/src/cms/preview-templates/CellLinePreview.tsx
+++ b/src/cms/preview-templates/CellLinePreview.tsx
@@ -3,12 +3,16 @@ import { CellLineTemplate } from '../../templates/cell-line'
 import { TemplateProps } from './types';
 
 const CellLinePreview = ({ entry }: TemplateProps) => {
+    const geneEntry = entry.getIn(["data", "gene"]);
+    const gene = geneEntry ?.join ? geneEntry.join(", ") : (geneEntry || "");
+    const tagLocationEntry = entry.getIn(["data", "tag_location"]);
+    const tagLocation = tagLocationEntry ?.join ? tagLocationEntry.join(", ") : (tagLocationEntry || "");
     return (
         <CellLineTemplate
             cellLineId={entry.getIn(["data", "cell_line_id"])}
             cloneNumber={entry.getIn(["data", "clone_number"])}
-            gene={entry.getIn(["data", "gene"])}
-            tagLocation={entry.getIn(["data", "tag_location"])}
+            gene={gene}
+            tagLocation={tagLocation}
             status={entry.getIn(["data", "status"])}
             thumbnail={entry.getIn(["data", "thumbnail_image"])}
         />

--- a/src/pages/cell-line/AICS-102/index.md
+++ b/src/pages/cell-line/AICS-102/index.md
@@ -4,7 +4,7 @@ cell_line_id: 102
 status: in progress
 date: 2025-02-05T17:41:29.111Z
 clone_number: 330
-parental_line: -2
+parental_line: 0
 gene: AAVS1
 allele_count: mono
 fluorescent_tag:

--- a/static/admin/config.yml
+++ b/static/admin/config.yml
@@ -94,6 +94,7 @@ collections:
                 value_field: "symbol",
                 display_fields: ["symbol"],
                 required: false,
+                multiple: true,
             }
           - {
                 label: "Allele Count",


### PR DESCRIPTION
Problem
=======
What is the problem this work solves, including
The scientists want to enter multiple genes for each normal cell line.

Solution
========
What I/we did to solve this problem
- set `multiple: true` for the `gene` field in config.yml
- updated the cell line cms preview to display multiple entries, joined by commas

## Type of change
Please delete options that are not relevant.
* New feature (non-breaking change which adds functionality)


Steps to Verify:
----------------
1. Click a normal cell line and enter multiple genes in admin page

Expected results:
<img width="687" alt="Screenshot 2025-02-05 at 3 06 05 PM" src="https://github.com/user-attachments/assets/0e0e803f-b65d-48f4-b2f8-a2a950bf8a2d" />


<img width="243" alt="Screenshot 2025-02-05 at 3 00 32 PM" src="https://github.com/user-attachments/assets/945660b1-5c87-412d-8aac-b27fb4b7d7fa" />

