### PR TITLE
Feature/tabs

### DIFF
--- a/src/components/SubpageTabs.tsx
+++ b/src/components/SubpageTabs.tsx
@@ -1,32 +1,36 @@
 import React from "react";
 import { Tabs } from "antd";
+import { SubPage } from "../types";
 
 const { container } = require("../style/subpage-tabs.module.css");
 
 // TODO: Swap out actual components for placeholders
-const tabNames = [
-    { name: "Editing Design", component: <div>Editing Design Content</div> },
-    {
-        name: "Genomic Characterization",
-        component: <div>Genomic Characterization Content</div>,
-    },
-    {
-        name: "Stem Cell Characteristics",
-        component: <div>Stem Cell Characteristics Content</div>,
-    },
-    { name: "Protocols", component: <div>Protocols Content</div> },
-];
+const tabComponents = {
+    [SubPage.EditingDesign]: <div>Editing Design Content</div>,
+    [SubPage.GenomicCharacterization]: (
+        <div>Genomic Characterization Content</div>
+    ),
+    [SubPage.StemCellCharacteristics]: (
+        <div>Stem Cell Characteristics Content</div>
+    ),
+    [SubPage.Protocols]: <div>Protocols Content</div>,
+};
 
-const SubpageTabs: React.FC = () => (
+interface SubpageTabsProps {
+    tabsToRender: SubPage[];
+}
+
+const SubpageTabs: React.FC<SubpageTabsProps> = ({ tabsToRender }) => (
     <Tabs
         className={container}
-        defaultActiveKey="1"
-        items={tabNames.map((data, i) => {
-            const id = String(i + 1);
+        defaultActiveKey={SubPage.EditingDesign}
+        items={tabsToRender.map((tabName) => {
+            // TODO: Render <TabName> is not yet available for this cell line
+            // if the data doesn't exist
             return {
-                label: data.name,
-                key: id,
-                children: data.component,
+                label: tabName,
+                key: tabName,
+                children: tabComponents[tabName],
             };
         })}
     />

--- a/src/components/SubpageTabs.tsx
+++ b/src/components/SubpageTabs.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { Flex, Tabs } from "antd";
 import { SubPage } from "../types";
 
-const { container } = require("../style/subpage-tabs.module.css");
+const { container, labelGroup } = require("../style/subpage-tabs.module.css");
 
 // TODO: Swap out actual components for placeholders
 const tabComponents = {
@@ -32,7 +32,12 @@ const SubpageTabs: React.FC<SubpageTabsProps> = ({ tabsToRender }) => (
             });
             return {
                 label: (
-                    <Flex wrap justify="center" align="center" gap={8}>
+                    <Flex
+                        wrap
+                        justify="center"
+                        align="center"
+                        className={labelGroup}
+                    >
                         {label}
                     </Flex>
                 ),

--- a/src/components/SubpageTabs.tsx
+++ b/src/components/SubpageTabs.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Tabs } from "antd";
+import { Flex, Tabs } from "antd";
 import { SubPage } from "../types";
 
 const { container } = require("../style/subpage-tabs.module.css");
@@ -27,8 +27,15 @@ const SubpageTabs: React.FC<SubpageTabsProps> = ({ tabsToRender }) => (
         items={tabsToRender.map((tabName) => {
             // TODO: Render <TabName> is not yet available for this cell line
             // if the data doesn't exist
+            const label = tabName.split(" ").map((word) => {
+                return <span>{word}</span>;
+            });
             return {
-                label: tabName,
+                label: (
+                    <Flex wrap justify="center" align="center" gap={8}>
+                        {label}
+                    </Flex>
+                ),
                 key: tabName,
                 children: tabComponents[tabName],
             };

--- a/src/components/SubpageTabs.tsx
+++ b/src/components/SubpageTabs.tsx
@@ -1,6 +1,8 @@
 import React from "react";
 import { Tabs } from "antd";
 
+const { container } = require("../style/subpage-tabs.module.css");
+
 const tabNames = [
     "Editing Design",
     "Genomic Characterization",
@@ -10,14 +12,14 @@ const tabNames = [
 
 const SubpageTabs: React.FC = () => (
     <Tabs
+        className={container}
         defaultActiveKey="1"
-        centered
-        items={tabNames.map((_, i) => {
+        items={tabNames.map((name, i) => {
             const id = String(i + 1);
             return {
-                label: `Tab ${id}`,
+                label: name,
                 key: id,
-                children: `Content of Tab Pane ${id}`,
+                children: `Contents of ${name}`,
             };
         })}
     />

--- a/src/components/SubpageTabs.tsx
+++ b/src/components/SubpageTabs.tsx
@@ -1,0 +1,26 @@
+import React from "react";
+import { Tabs } from "antd";
+
+const tabNames = [
+    "Editing Design",
+    "Genomic Characterization",
+    "Stem Cell Characteristics",
+    "Protocols",
+];
+
+const SubpageTabs: React.FC = () => (
+    <Tabs
+        defaultActiveKey="1"
+        centered
+        items={tabNames.map((_, i) => {
+            const id = String(i + 1);
+            return {
+                label: `Tab ${id}`,
+                key: id,
+                children: `Content of Tab Pane ${id}`,
+            };
+        })}
+    />
+);
+
+export default SubpageTabs;

--- a/src/components/SubpageTabs.tsx
+++ b/src/components/SubpageTabs.tsx
@@ -3,23 +3,30 @@ import { Tabs } from "antd";
 
 const { container } = require("../style/subpage-tabs.module.css");
 
+// TODO: Swap out actual components for placeholders
 const tabNames = [
-    "Editing Design",
-    "Genomic Characterization",
-    "Stem Cell Characteristics",
-    "Protocols",
+    { name: "Editing Design", component: <div>Editing Design Content</div> },
+    {
+        name: "Genomic Characterization",
+        component: <div>Genomic Characterization Content</div>,
+    },
+    {
+        name: "Stem Cell Characteristics",
+        component: <div>Stem Cell Characteristics Content</div>,
+    },
+    { name: "Protocols", component: <div>Protocols Content</div> },
 ];
 
 const SubpageTabs: React.FC = () => (
     <Tabs
         className={container}
         defaultActiveKey="1"
-        items={tabNames.map((name, i) => {
+        items={tabNames.map((data, i) => {
             const id = String(i + 1);
             return {
-                label: name,
+                label: data.name,
                 key: id,
-                children: `Contents of ${name}`,
+                children: data.component,
             };
         })}
     />

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,3 +1,18 @@
+import { SubPage } from "../types";
+
 export const TABLET_BREAKPOINT = 768;
 export const PHONE_BREAKPOINT = 576;
 export const PRODUCTION_HOST = "https://cell-catalog.allencell.org/";
+
+export const DEFAULT_TABS = [
+    SubPage.EditingDesign,
+    SubPage.GenomicCharacterization,
+    SubPage.Protocols,
+];
+
+export const TABS_WITH_STEM_CELL = [
+    SubPage.EditingDesign,
+    SubPage.GenomicCharacterization,
+    SubPage.StemCellCharacteristics,
+    SubPage.Protocols,
+];

--- a/src/style/subpage-tabs.module.css
+++ b/src/style/subpage-tabs.module.css
@@ -12,7 +12,7 @@
 .container :global(.ant-tabs-tab) {
     text-align: center;
     flex: 1 1 0px;
-    width: 100%;
+    width: 0;
     margin: auto;
     justify-content: center;
     padding: 0;
@@ -29,8 +29,12 @@
     font-weight: 700;
     font-size: 20px;
     line-height: 27px;
-    padding: 4px 8px;
-    text-wrap: initial;
+    padding: 4px 24px;
+}
+
+.label {
+    flex-wrap: wrap;
+    gap: 8px;
 }
 
 .container :global(.ant-tabs-tab-active .ant-tabs-tab-btn) {

--- a/src/style/subpage-tabs.module.css
+++ b/src/style/subpage-tabs.module.css
@@ -1,0 +1,44 @@
+.container {
+    margin-bottom: 20px;
+}
+
+.container :global(.ant-tabs-nav-list) {
+    display: flex;
+    justify-content: space-between;
+    width: 100%;
+    gap: 24px;
+}
+
+.container :global(.ant-tabs-tab) {
+    text-align: center;
+    flex: 1 1 0px;
+    width: 0;
+    margin: auto;
+    justify-content: center;
+    padding: 0;
+    border: 1px solid var(--primary-color);
+    border-radius: 5px;
+}
+
+.container :global(.ant-tabs-tab-btn) {
+    width: 100%;
+    height: 84px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-weight: 700;
+    font-size: 20px;
+    line-height: 27px;
+    padding: 4px 8px;
+    text-wrap: initial;
+}
+
+.container :global(.ant-tabs-tab-active .ant-tabs-tab-btn) {
+    background-color: var(--primary-color);
+    color: white !important;
+}
+
+.container :global(.ant-tabs-ink-bar) {
+    display: none;
+    width: 0;
+}

--- a/src/style/subpage-tabs.module.css
+++ b/src/style/subpage-tabs.module.css
@@ -20,6 +20,11 @@
     border-radius: 5px;
 }
 
+.container :global(.ant-tabs-tab):hover {
+    color: var(--primary-color);
+    background-color: white;
+}
+
 .container :global(.ant-tabs-tab-btn) {
     width: 100%;
     height: 84px;

--- a/src/style/subpage-tabs.module.css
+++ b/src/style/subpage-tabs.module.css
@@ -32,9 +32,9 @@
     padding: 4px 24px;
 }
 
-.label {
-    flex-wrap: wrap;
-    gap: 8px;
+.label-group {
+    column-gap: 8px;
+    row-gap: 0;
 }
 
 .container :global(.ant-tabs-tab-active .ant-tabs-tab-btn) {
@@ -45,4 +45,10 @@
 .container :global(.ant-tabs-ink-bar) {
     display: none;
     width: 0;
+}
+
+@media (max-width: 1024px) {
+    .container :global(.ant-tabs-tab-btn) {
+        font-size: 16px;
+    }
 }

--- a/src/style/subpage-tabs.module.css
+++ b/src/style/subpage-tabs.module.css
@@ -12,7 +12,7 @@
 .container :global(.ant-tabs-tab) {
     text-align: center;
     flex: 1 1 0px;
-    width: 0;
+    width: 100%;
     margin: auto;
     justify-content: center;
     padding: 0;

--- a/src/templates/disease-cell-line.tsx
+++ b/src/templates/disease-cell-line.tsx
@@ -12,6 +12,7 @@ import {
 import { DefaultButton } from "../components/shared/Buttons";
 import ImagesAndVideos from "../components/ImagesAndVideos";
 import CellLineInfoCard from "../components/CellLineInfoCard";
+import SubpageTabs from "../components/SubpageTabs";
 
 const {
     container,
@@ -120,6 +121,7 @@ const CellLine = ({ data, location }: QueryResult) => {
                 }
                 imagesAndVideos={cellLine.frontmatter.images_and_videos}
             />
+            <SubpageTabs />
         </Layout>
     );
 };

--- a/src/templates/disease-cell-line.tsx
+++ b/src/templates/disease-cell-line.tsx
@@ -13,6 +13,8 @@ import { DefaultButton } from "../components/shared/Buttons";
 import ImagesAndVideos from "../components/ImagesAndVideos";
 import CellLineInfoCard from "../components/CellLineInfoCard";
 import SubpageTabs from "../components/SubpageTabs";
+import { DEFAULT_TABS, TABS_WITH_STEM_CELL } from "../constants";
+import { Disease } from "../types";
 
 const {
     container,
@@ -36,6 +38,7 @@ interface DiseaseCellLineTemplateProps {
     clones: Clone[];
     healthCertificate: string;
     imagesAndVideos: any;
+    diseaseName: string;
 }
 
 // eslint-disable-next-line
@@ -52,46 +55,59 @@ export const DiseaseCellLineTemplate = ({
     parentalLine,
     healthCertificate,
     imagesAndVideos,
+    diseaseName,
 }: DiseaseCellLineTemplateProps) => {
     const hasImagesOrVideos =
         (imagesAndVideos?.images?.length || 0) > 0 ||
         (imagesAndVideos?.videos?.length || 0) > 0;
     return (
-        <Flex className={container} gap={40} justify="space-between">
-            <Flex vertical gap={16} className={leftCard}>
-                <Link to="/disease-catalog">
-                    <DefaultButton>
-                        <Arrow className={returnArrow} />
-                        Return to Cell Catalog
-                    </DefaultButton>
-                </Link>
-                <CellLineInfoCard
-                    href={href}
-                    cellLineId={cellLineId}
-                    parentLineGene={parentLineGene}
-                    geneName={geneName}
-                    geneSymbol={geneSymbol}
-                    clones={clones}
-                    snp={snp}
-                    orderLink={orderLink}
-                    certificateOfAnalysis={certificateOfAnalysis}
-                    parentalLine={parentalLine}
-                    healthCertificate={healthCertificate}
-                />
+        <>
+            <Flex className={container} gap={40} justify="space-between">
+                <Flex vertical gap={16} className={leftCard}>
+                    <Link to="/disease-catalog">
+                        <DefaultButton>
+                            <Arrow className={returnArrow} />
+                            Return to Cell Catalog
+                        </DefaultButton>
+                    </Link>
+                    <CellLineInfoCard
+                        href={href}
+                        cellLineId={cellLineId}
+                        parentLineGene={parentLineGene}
+                        geneName={geneName}
+                        geneSymbol={geneSymbol}
+                        clones={clones}
+                        snp={snp}
+                        orderLink={orderLink}
+                        certificateOfAnalysis={certificateOfAnalysis}
+                        parentalLine={parentalLine}
+                        healthCertificate={healthCertificate}
+                    />
+                </Flex>
+                {hasImagesOrVideos && (
+                    <ImagesAndVideos
+                        cellLineId={cellLineId}
+                        fluorescentTag={parentalLine.fluorescent_tag}
+                        parentalGeneSymbol={
+                            parentalLine.gene.frontmatter.symbol
+                        }
+                        alleleTag={parentalLine.allele_count}
+                        parentalLine={parentalLine}
+                        geneSymbol={geneSymbol}
+                        snp={snp}
+                        images={imagesAndVideos.images}
+                    />
+                )}
             </Flex>
-            {hasImagesOrVideos && (
-                <ImagesAndVideos
-                    cellLineId={cellLineId}
-                    fluorescentTag={parentalLine.fluorescent_tag}
-                    parentalGeneSymbol={parentalLine.gene.frontmatter.symbol}
-                    alleleTag={parentalLine.allele_count}
-                    parentalLine={parentalLine}
-                    geneSymbol={geneSymbol}
-                    snp={snp}
-                    images={imagesAndVideos.images}
-                />
-            )}
-        </Flex>
+            <Divider />
+            <SubpageTabs // TODO: request subpage data and send it in here
+                tabsToRender={
+                    diseaseName === Disease.Cardiomyopathy
+                        ? TABS_WITH_STEM_CELL
+                        : DEFAULT_TABS
+                }
+            />
+        </>
     );
 };
 
@@ -100,10 +116,12 @@ const CellLine = ({ data, location }: QueryResult) => {
     const parentalLineData = cellLine.frontmatter.parental_line.frontmatter;
     const { name: geneName, symbol: geneSymbol } =
         cellLine.frontmatter.disease.frontmatter.gene.frontmatter;
+    const diseaseName = cellLine.frontmatter.disease.frontmatter.name;
     return (
         <Layout>
             <DiseaseCellLineTemplate
                 href={location.href || ""}
+                diseaseName={diseaseName}
                 cellLineId={cellLine.frontmatter.cell_line_id}
                 snp={cellLine.frontmatter.snp}
                 orderLink={cellLine.frontmatter.order_link}
@@ -121,8 +139,6 @@ const CellLine = ({ data, location }: QueryResult) => {
                 }
                 imagesAndVideos={cellLine.frontmatter.images_and_videos}
             />
-            <Divider />
-            <SubpageTabs />
         </Layout>
     );
 };

--- a/src/templates/disease-cell-line.tsx
+++ b/src/templates/disease-cell-line.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { graphql, Link } from "gatsby";
-import { Flex } from "antd";
+import { Divider, Flex } from "antd";
 
 import Layout from "../components/Layout";
 import {
@@ -121,6 +121,7 @@ const CellLine = ({ data, location }: QueryResult) => {
                 }
                 imagesAndVideos={cellLine.frontmatter.images_and_videos}
             />
+            <Divider />
             <SubpageTabs />
         </Layout>
     );

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,12 @@
+export enum SubPage {
+    EditingDesign = "Editing Design",
+    GenomicCharacterization = "Genomic Characterization",
+    StemCellCharacteristics = "Stem Cell Characteristics",
+    Protocols = "Protocols",
+}
+
+export enum Disease {
+    Cardiomyopathy = "Cardiomyopathy",
+    Laminopathy = "Laminopathy",
+    SkeletalMyopathy = "Skeletal Myopathy",
+}


### PR DESCRIPTION
Problem
=======
[the design](https://www.figma.com/design/kMIJN6BoOkXIhnVUruIHNT/Website-allencell.org?node-id=2639-7577&t=0JIe0EFdlTp2BGQe-0) has 4 subpages 

Solution
========
Render 4 tabs with placeholder components 

## Type of change
Please delete options that are not relevant.

* New feature (non-breaking change which adds functionality)


Steps to Verify:
----------------
1. go to preview of the disease-catalog
2. click a cell line 
3. should see the tabs (4 for cardio and 3 for the others)

