### PR TITLE
disable wheel hook for number inputs 

### DIFF
--- a/src/cms/hooks/useDisableWheel.ts
+++ b/src/cms/hooks/useDisableWheel.ts
@@ -1,0 +1,16 @@
+import { useEffect } from "react";
+
+const useDisableWheel = () => {
+    useEffect(() => {
+        document.addEventListener("wheel", function (event) {
+            if (
+                document.activeElement &&
+                (document.activeElement as HTMLInputElement).type === "number"
+            ) {
+                (document.activeElement as HTMLInputElement).blur();
+            }
+        });
+    }, []);
+};
+
+export default useDisableWheel;

--- a/src/cms/preview-templates/CellLinePreview.tsx
+++ b/src/cms/preview-templates/CellLinePreview.tsx
@@ -1,12 +1,16 @@
-import React from 'react'
-import { CellLineTemplate } from '../../templates/cell-line'
-import { TemplateProps } from './types';
+import React from "react";
+import { CellLineTemplate } from "../../templates/cell-line";
+import { TemplateProps } from "./types";
+import useDisableWheel from "../hooks/useDisableWheel";
 
 const CellLinePreview = ({ entry }: TemplateProps) => {
     const geneEntry = entry.getIn(["data", "gene"]);
-    const gene = geneEntry ?.join ? geneEntry.join(", ") : (geneEntry || "");
+    const gene = geneEntry?.join ? geneEntry.join(", ") : geneEntry || "";
     const tagLocationEntry = entry.getIn(["data", "tag_location"]);
-    const tagLocation = tagLocationEntry ?.join ? tagLocationEntry.join(", ") : (tagLocationEntry || "");
+    const tagLocation = tagLocationEntry?.join
+        ? tagLocationEntry.join(", ")
+        : tagLocationEntry || "";
+    useDisableWheel();
     return (
         <CellLineTemplate
             cellLineId={entry.getIn(["data", "cell_line_id"])}
@@ -19,4 +23,4 @@ const CellLinePreview = ({ entry }: TemplateProps) => {
     );
 };
 
-export default CellLinePreview
+export default CellLinePreview;

--- a/src/cms/preview-templates/DiseaseCellLinePreview.tsx
+++ b/src/cms/preview-templates/DiseaseCellLinePreview.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect } from "react";
 
 import { TemplateProps } from "./types";
 import InfoPanel from "../../components/shared/InfoPanel";
@@ -7,10 +7,11 @@ import CloneTable from "../../components/CloneTable";
 import { Clone } from "../../component-queries/types";
 import PreviewCompatibleImage from "../../components/PreviewCompatibleImage";
 import ProgressPreview from "./ProgressPreview";
+import useDisableWheel from "../hooks/useDisableWheel";
 
 const DiseaseCellLinePreview = ({ entry, getAsset }: TemplateProps) => {
     const parental_line_id = entry.getIn(["data", "parental_line"]);
-
+    useDisableWheel();
     const data = [
         {
             key: "cell_line_id",


### PR DESCRIPTION
Problem
=======
What is the problem this work solves, including
closes #98 

Solution
========
What I/we did to solve this problem
- add a hook that adds an event listener to blur `number` inputs whenever a mouse wheel event occurs

with @meganrm 

## Type of change
Please delete options that are not relevant.

* Bug fix (non-breaking change which fixes an issue)

Steps to Verify:
----------------
1. In the cms, scroll the mouse wheel while a number input is in focus
