### PR TITLE
clones data structure

### DIFF
--- a/src/pages/disease-cell-line/AICS-104/index.md
+++ b/src/pages/disease-cell-line/AICS-104/index.md
@@ -11,18 +11,22 @@ clones:
     clone_number: 3
     transfection_replicate: A
     genotype: H251N/WT
+    positive_cells: 82
   - type: Control
     clone_number: 4
     transfection_replicate: A
     genotype: WT/WT
+    positive_cells: 92
   - type: Control
     clone_number: 6
     transfection_replicate: A
     genotype: WT/WT
+    positive_cells: 49
   - type: Mutant
     clone_number: 85
     transfection_replicate: B
     genotype: H251N/WT
+    positive_cells: 79
 order_link: https://www.coriell.org/0/Sections/Search/DiseaseCollection_Detail.aspx?Ref=AICS-0104&Product=CiPSC&PgId=166
 certificate_of_analysis: https://www.coriell.org/0/PDF/Allen/iPSC/AICS-0104_CofA.pdf
 images_and_videos:
@@ -81,13 +85,4 @@ editing_design:
       image: actn2_fullfigure.png
       caption: "Top: ACTN2 locus showing 3 ACTN2 isoforms; Bottom: Zoom in on mEGFP
         insertion site at ACTN2 C-terminus"
-stem_cell_characteristics:
-  - clone_number: 3
-    positive_cells: 82
-  - clone_number: 4
-    positive_cells: 92
-  - clone_number: 6
-    positive_cells: 49
-  - clone_number: 85
-    positive_cells: 79
 ---

--- a/src/pages/disease-cell-line/AICS-105/index.md
+++ b/src/pages/disease-cell-line/AICS-105/index.md
@@ -11,26 +11,32 @@ clones:
     clone_number: 22
     transfection_replicate: A
     genotype: WT/WT
+    positive_cells: 50
   - type: Mutant
     clone_number: 30
     transfection_replicate: A
     genotype: R369Q/WT
+    positive_cells: 52
   - type: Mutant
     clone_number: 31
     transfection_replicate: A
     genotype: R369Q/R369Q
+    positive_cells: 48
   - type: Mutant
     clone_number: 32
     transfection_replicate: A
     genotype: R369Q/WT
+    positive_cells: 54
   - type: Mutant
     clone_number: 57
     transfection_replicate: B
     genotype: R369Q/WT
+    positive_cells: 36
   - type: Control
     clone_number: 89
     transfection_replicate: B
     genotype: WT/WT
+    positive_cells: 57
 order_link: https://www.coriell.org/0/Sections/Search/DiseaseCollection_Detail.aspx?Ref=AICS-0105&Product=CiPSC&PgId=166
 certificate_of_analysis: https://www.coriell.org/0/PDF/Allen/iPSC/AICS-0105_CofA.pdf
 images_and_videos:
@@ -89,17 +95,4 @@ editing_design:
       caption: "Top: ACTN2 locus showing 3 ACTN2 isoforms; Bottom: Zoom in on mEGFP
         insertion site at ACTN2 C-terminus"
       image: actn2_fullfigure.png
-stem_cell_characteristics:
-  - clone_number: 22
-    positive_cells: 50
-  - clone_number: 30
-    positive_cells: 52
-  - clone_number: 31
-    positive_cells: 48
-  - clone_number: 32
-    positive_cells: 54
-  - clone_number: 57
-    positive_cells: 36
-  - clone_number: 89
-    positive_cells: 57
 ---

--- a/src/pages/disease-cell-line/AICS-106/index.md
+++ b/src/pages/disease-cell-line/AICS-106/index.md
@@ -13,9 +13,6 @@ clones:
     genotype: WT/WT
     positive_cells: 73
   - type: Control
-    clone_number: 88
-    positive_cells: 66
-  - type: Control
     clone_number: 86
     transfection_replicate: B
     genotype: WT/WT

--- a/src/pages/disease-cell-line/AICS-106/index.md
+++ b/src/pages/disease-cell-line/AICS-106/index.md
@@ -11,6 +11,10 @@ clones:
     clone_number: 40
     transfection_replicate: A
     genotype: WT/WT
+    positive_cells: 73
+  - type: Control
+    clone_number: 88
+    positive_cells: 66
   - type: Control
     clone_number: 86
     transfection_replicate: B
@@ -19,10 +23,12 @@ clones:
     clone_number: 104
     transfection_replicate: A
     genotype: S291F/WT
+    positive_cells: 75
   - type: Mutant
     clone_number: 134
     transfection_replicate: A
     genotype: S291F/WT
+    positive_cells: 73
 order_link: https://www.coriell.org/0/Sections/Search/DiseaseCollection_Detail.aspx?Ref=AICS-0106&Product=CiPSC&PgId=166
 certificate_of_analysis: https://www.coriell.org/0/PDF/Allen/iPSC/AICS-0106_CofA.pdf
 images_and_videos:
@@ -72,13 +78,4 @@ editing_design:
       caption: "Top: ACTN2 locus showing 3 ACTN2 isoforms; Bottom: Zoom in on mEGFP
         insertion site at ACTN2 C-terminus"
       image: actn2_fullfigure.png
-stem_cell_characteristics:
-  - clone_number: 40
-    positive_cells: 73
-  - clone_number: 88
-    positive_cells: 66
-  - clone_number: 104
-    positive_cells: 75
-  - clone_number: 134
-    positive_cells: 73
 ---

--- a/src/pages/disease-cell-line/AICS-107/index.md
+++ b/src/pages/disease-cell-line/AICS-107/index.md
@@ -11,14 +11,17 @@ clones:
     clone_number: 9
     transfection_replicate: A
     genotype: V606M/WT
+    positive_cells: 72
   - type: Mutant
     clone_number: 17
     transfection_replicate: A
     genotype: V606M/WT
+    positive_cells: 74
   - type: Control
     clone_number: 63
     transfection_replicate: B
     genotype: WT/WT
+    positive_cells: 73
 order_link: https://www.coriell.org/0/Sections/Search/DiseaseCollection_Detail.aspx?Ref=AICS-0107&Product=CiPSC&PgId=166
 certificate_of_analysis: https://www.coriell.org/0/PDF/Allen/iPSC/AICS-0107_CofA.pdf
 images_and_videos:
@@ -70,11 +73,4 @@ editing_design:
       caption: "Top: ACTN2 locus showing 3 ACTN2 isoforms; Bottom: Zoom in on mEGFP
         insertion site at ACTN2 C-terminus"
       image: actn2_fullfigure.png
-stem_cell_characteristics:
-  - clone_number: 9
-    positive_cells: 72
-  - clone_number: 17
-    positive_cells: 74
-  - clone_number: 63
-    positive_cells: 73
 ---

--- a/src/pages/disease-cell-line/AICS-109/index.md
+++ b/src/pages/disease-cell-line/AICS-109/index.md
@@ -11,18 +11,22 @@ clones:
     clone_number: 55
     transfection_replicate: B
     genotype: WT/WT
+    positive_cells: 58
   - type: Mutant
     clone_number: 56
     transfection_replicate: B
     genotype: E525K/WT
+    positive_cells: 76
   - type: Control
     clone_number: 72
     transfection_replicate: B
     genotype: WT/WT
+    positive_cells: 73
   - type: Mutant
     clone_number: 93
     transfection_replicate: B
     genotype: E525K/WT
+    positive_cells: 62
 order_link: https://www.coriell.org/0/Sections/Search/DiseaseCollection_Detail.aspx?Ref=AICS-0109&Product=CiPSC&PgId=166
 certificate_of_analysis: https://www.coriell.org/0/PDF/Allen/iPSC/AICS-0109_CofA.pdf
 images_and_videos:
@@ -72,13 +76,4 @@ editing_design:
       caption: "Top: ACTN2 locus showing 3 ACTN2 isoforms; Bottom: Zoom in on mEGFP
         insertion site at ACTN2 C-terminus"
       image: actn2_fullfigure.png
-stem_cell_characteristics:
-  - clone_number: 55
-    positive_cells: 58
-  - clone_number: 56
-    positive_cells: 76
-  - clone_number: 72
-    positive_cells: 73
-  - clone_number: 93
-    positive_cells: 62
 ---

--- a/src/pages/disease-cell-line/AICS-97/index.md
+++ b/src/pages/disease-cell-line/AICS-97/index.md
@@ -11,22 +11,27 @@ clones:
     clone_number: 102
     transfection_replicate: A
     genotype: G256E/WT
+    positive_cells: 86
   - type: Control
     clone_number: 113
     transfection_replicate: A
     genotype: WT/WT
+    positive_cells: 76
   - type: Mutant
     clone_number: 141
     transfection_replicate: A
     genotype: G256E/WT
+    positive_cells: 77
   - type: Mutant
     clone_number: 157
     transfection_replicate: B
     genotype: G256E/WT
+    positive_cells: 76
   - type: Control
     clone_number: 174
     transfection_replicate: B
     genotype: WT/WT
+    positive_cells: 74
 order_link: https://www.coriell.org/0/Sections/Search/DiseaseCollection_Detail.aspx?Ref=AICS-0097&Product=CiPSC&PgId=166
 certificate_of_analysis: https://www.coriell.org/0/PDF/Allen/iPSC/AICS-0097_CofA.pdf
 images_and_videos:
@@ -86,15 +91,4 @@ editing_design:
       image: actn2_fullfigure.png
       caption: "Top: ACTN2 locus showing 3 ACTN2 isoforms; Bottom: Zoom in on mEGFP
         insertion site at ACTN2 C-terminus"
-stem_cell_characteristics:
-  - clone_number: 102
-    positive_cells: 86
-  - clone_number: 113
-    positive_cells: 76
-  - clone_number: 141
-    positive_cells: 77
-  - clone_number: 157
-    positive_cells: 76
-  - clone_number: 174
-    positive_cells: 74
 ---

--- a/static/admin/config.yml
+++ b/static/admin/config.yml
@@ -289,8 +289,66 @@ collections:
                             widget: "string",
                             required: false,
                         },
-                    ],
-            }
+                        {
+                            label: "Troponin T, % Positive Cells(n)",
+                            name: "positive_cells",
+                            widget: "number",
+                            value_type: "float",
+                            required: false,
+                        },
+                        {
+                            label: "Passing Antibodies",
+                            name: "antibody_analysis",
+                            hint: "select all antibodies this clone passed ",
+                            widget: "select",
+                            options: ["PAX6", "SOX17", "Brachyury"],
+                            multiple: true,
+                        },
+                        {
+                            label: "Differentiation",
+                            name: "differentiation",
+                            widget: "list",
+                            required: false,
+                            fields:
+                                [
+                                    {
+                                        label: "NANOG",
+                                        name: "nanog",
+                                        widget: "number",
+                                        value_type: "float",
+                                        required: false,
+                                    },
+                                    {
+                                        label: "SOX2",
+                                        name: "sox_2",
+                                        widget: "number",
+                                        value_type: "float",
+                                        required: false,
+                                    },
+                                    {
+                                        label: "OCT4",
+                                        name: "oct_4",
+                                        widget: "number",
+                                        value_type: "float",
+                                        required: false,
+                                    },
+                                    {
+                                        label: "SSEA-1",
+                                        name: "ssea_1",
+                                        widget: "number",
+                                        value_type: "float",
+                                        required: false,
+                                    },
+                                    {
+                                        label: "SSEA-4",
+                                        name: "ssea_4",
+                                        widget: "number",
+                                        value_type: "float",
+                                        required: false,
+                                    },
+                                ],
+                        },
+                    ] }
           - {
                 label: "Order Link",
                 name: "order_link",
@@ -453,28 +511,6 @@ collections:
                                         widget: "string",
                                     },
                                 ],
-                        },
-                    ],
-            }
-          - {
-                label: "Stem Cell Characteristics",
-                name: "stem_cell_characteristics",
-                widget: "list",
-                required: false,
-                collapsed: true,
-                fields:
-                    [
-                        {
-                            label: "Clone number",
-                            name: "clone_number",
-                            widget: "number",
-                            required: false,
-                        },
-                        {
-                            label: "Troponin T, % Positive Cells(n)",
-                            name: "positive_cells",
-                            widget: "number",
-                            required: false,
                         },
                     ],
             }


### PR DESCRIPTION
Problem
=======
Closes #105 and #106 

Solution
========

Added `positive_cells`, `antibody_analysis`, and `differentiation` to `clones`.
Deleted `stem_cell_characteristics.`

Data was updated and I found one discrepancy:
clone number 88 in AICS-106 had a value for `positive_cells` but not a clone entry. I created a clone entry, and chose type: Control, as that is a required field, but I don't know what it actually should be, or any of the other data associated with it.

Letting users add new antibodies is not possible with the basic select widget.
