### PR TITLE
Enable Editorial Workflow

### DIFF
--- a/static/admin/config.yml
+++ b/static/admin/config.yml
@@ -1,5 +1,6 @@
 backend:
     name: git-gateway
+    repo: allen-cell-animated/cell-catalog
     branch: main
     commit_messages:
         create: "Create {{collection}} “{{slug}}”"
@@ -7,8 +8,10 @@ backend:
         delete: "Delete {{collection}} “{{slug}}”"
         uploadMedia: "[skip ci] Upload “{{path}}”"
         deleteMedia: "[skip ci] Delete “{{path}}”"
+    squash_merges: true
 
-local_backend: true
+publish_mode: editorial_workflow
+# local_backend: true
 media_folder: static/img
 public_folder: /img
 
@@ -75,7 +78,7 @@ collections:
                 label: "Clone Number",
                 name: "clone_number",
                 widget: "number",
-                valueType: int,
+                value_type: int,
                 required: false,
             }
           - {

--- a/static/admin/config.yml
+++ b/static/admin/config.yml
@@ -78,7 +78,7 @@ collections:
                 label: "Clone Number",
                 name: "clone_number",
                 widget: "number",
-                value_type: int,
+                valueType: int,
                 required: false,
             }
           - {
@@ -296,7 +296,7 @@ collections:
                             label: "Troponin T, % Positive Cells(n)",
                             name: "positive_cells",
                             widget: "number",
-                            value_type: "float",
+                            valueType: "float",
                             required: false,
                         },
                         {

--- a/static/admin/config.yml
+++ b/static/admin/config.yml
@@ -296,7 +296,7 @@ collections:
                             label: "Troponin T, % Positive Cells(n)",
                             name: "positive_cells",
                             widget: "number",
-                            valueType: "float",
+                            value_type: "float",
                             required: false,
                         },
                         {

--- a/static/admin/config.yml
+++ b/static/admin/config.yml
@@ -11,7 +11,7 @@ backend:
     squash_merges: true
 
 publish_mode: editorial_workflow
-# local_backend: true
+local_backend: true
 media_folder: static/img
 public_folder: /img
 


### PR DESCRIPTION
Problem
=======
What is the problem this work solves, including
closes #102 

Solution
========
What I/we did to solve this problem
- added `publish_mode: editorial_workflow` to create a new tab `Workflow` in CMS, which provides a structured review workflow for new content changes
- kept `local_backend: true` for local development, note that local filesystem backend doesn't support editorial workflows. You'll see the warning `'editorial_workflow' is not supported by 'local_fs' backend, switching to 'simple'
` in console while using local backends.



## Type of change
Please delete options that are not relevant.

* New feature (non-breaking change which adds functionality)

Steps to Verify:
----------------
1. The `Workflow` tab is visible on [preview site](https://deploy-preview-118--cell-catalog.netlify.app/admin)
2. Note: `Workflow` tab won't show up during local development ( I'm open to suggestions on how we might better handle or display the tab in the local backend)

Screenshots (optional):
-----------------------
- save changes and request review 
<img width="1000" alt="Screenshot 2025-03-24 at 1 03 20 PM" src="https://github.com/user-attachments/assets/ff1a1954-0c72-4b92-9195-4ce1d4cff905" />

- workflow tab
<img width="1200" alt="Screenshot 2025-03-24 at 1 04 54 PM" src="https://github.com/user-attachments/assets/f83fb43e-a6d1-47bc-be90-6aad46c712c4" />
