### PR TITLE
Update data handling for gene, tag_location, fluorescent_tag arrays 

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -108,7 +108,7 @@ module.exports = {
         "gatsby-plugin-netlify", // make sure to keep it last in the array
     ],
     mapping: {
-        "MarkdownRemark.frontmatter.gene": `MarkdownRemark.frontmatter.symbol`,
+        "MarkdownRemark.frontmatter.gene": `[MarkdownRemark.frontmatter.symbol]`,
         "MarkdownRemark.frontmatter.disease": `MarkdownRemark.frontmatter.name`,
         "MarkdownRemark.frontmatter.parental_line": `MarkdownRemark.frontmatter.cell_line_id`,
     },

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -8,7 +8,7 @@ exports.createSchemaCustomization = ({ actions, schema }) => {
         "type MarkdownRemark implements Node { frontmatter: Frontmatter }",
         `type Frontmatter {
             disease: MarkdownRemark @link(by: "frontmatter.name")
-            gene: MarkdownRemark @link(by: "frontmatter.symbol")
+            gene: [MarkdownRemark] @link(by: "frontmatter.symbol", from: "gene") 
             parental_line: MarkdownRemark @link(by: "frontmatter.cell_line_id")
             footer_text: String @md
             acknowledgements: String @md

--- a/src/component-queries/Diseases.tsx
+++ b/src/component-queries/Diseases.tsx
@@ -36,8 +36,8 @@ const DiseaseTemplate = (props: QueryResult) => {
             disease.frontmatter;
             return {
                 name,
-                geneSymbol: gene.frontmatter.symbol,
-                geneName: gene.frontmatter.name,
+                geneSymbol: gene[0].frontmatter.symbol,
+                geneName: gene[0].frontmatter.name,
                 acknowledgements: acknowledgements.html,
                 status,
             };

--- a/src/component-queries/convert-data.ts
+++ b/src/component-queries/convert-data.ts
@@ -7,12 +7,6 @@ import {
     UnpackedNormalCellLine,
 } from "./types";
 
-const multipleValues = (value: string | string[] | undefined): string => {
-    if (!value || value.length === 0) return "";
-    if (typeof value === "string") return value;
-    return value.length > 1 ? value.join(", ") : value[0];
-};
-
 
 const extractGenes = (geneArray: { frontmatter: GeneFrontMatter }[] = []): UnpackedGene[] => {
     if (!geneArray) return [];
@@ -57,11 +51,10 @@ export const convertFrontmatterToDiseaseCellLine = (
                 cellLineNode.frontmatter.parental_line.frontmatter.cell_line_id,
             cloneNumber:
                 cellLineNode.frontmatter.parental_line.frontmatter.clone_number,
-            tagLocation:
-                multipleValues(cellLineNode.frontmatter.parental_line.frontmatter.tag_location),
-            fluorescentTag:
-                multipleValues(cellLineNode.frontmatter.parental_line.frontmatter
-                    .fluorescent_tag),
+            tagLocation: 
+                cellLineNode.frontmatter.parental_line.frontmatter.tag_location,
+            fluorescentTag: 
+                cellLineNode.frontmatter.parental_line.frontmatter.fluorescent_tag,
             taggedGene: parentalGenes,
         },
         key: cellLineNode.id,
@@ -76,14 +69,14 @@ export const convertFrontmatterToNormalCellLines = ({
     const genes = extractGenes(cellLineNode.frontmatter.gene);
     const proteins = genes.map((gene) => gene.protein || "");
     const structures = genes.map((gene) => gene.structure || "");
-
+    // TODO: check multi-tag with UX
     return {
         path: cellLineNode.fields.slug,
         cellLineId: cellLineNode.frontmatter.cell_line_id,
         cloneNumber: cellLineNode.frontmatter.clone_number,
         alleleCount: cellLineNode.frontmatter.allele_count,
-        fluorescentTag: multipleValues(cellLineNode.frontmatter.fluorescent_tag),
-        tagLocation: multipleValues(cellLineNode.frontmatter.tag_location),
+        fluorescentTag: cellLineNode.frontmatter.fluorescent_tag,
+        tagLocation: cellLineNode.frontmatter.tag_location,
         parentalLine: cellLineNode.frontmatter.parental_line.frontmatter.name,
         protein: proteins.join(", "),
         taggedGene: genes,

--- a/src/component-queries/convert-data.ts
+++ b/src/component-queries/convert-data.ts
@@ -67,7 +67,6 @@ export const convertFrontmatterToNormalCellLines = ({
     const genes = extractGenes(cellLineNode.frontmatter.gene);
     const proteins = genes.map((gene) => gene.protein || "");
     const structures = genes.map((gene) => gene.structure || "");
-    // TODO: check multi-tag with UX
     return {
         path: cellLineNode.fields.slug,
         cellLineId: cellLineNode.frontmatter.cell_line_id,
@@ -76,9 +75,9 @@ export const convertFrontmatterToNormalCellLines = ({
         fluorescentTag: cellLineNode.frontmatter.fluorescent_tag,
         tagLocation: cellLineNode.frontmatter.tag_location,
         parentalLine: cellLineNode.frontmatter.parental_line.frontmatter.name,
-        protein: proteins.join(", "),
+        protein: proteins.join(" / "),
         taggedGene: genes,
-        structure: structures.join(", "),
+        structure: structures.join(" / "),
         status: cellLineNode.frontmatter.status,
         certificateOfAnalysis: "",
         healthCertificate: "",

--- a/src/component-queries/convert-data.ts
+++ b/src/component-queries/convert-data.ts
@@ -5,6 +5,12 @@ import {
     UnpackedNormalCellLine,
 } from "./types";
 
+const multipleValues = (value: string | string[] | undefined): string => {
+    if (!value || value.length === 0) return "";
+    if (typeof value === "string") return value;
+    return value.length > 1 ? value.join(", ") : value[0];
+};
+
 export const convertFrontmatterToDiseaseCellLine = (
     cellLineNode: DiseaseCellLineNode
 ): UnpackedDiseaseCellLine => {
@@ -32,10 +38,10 @@ export const convertFrontmatterToDiseaseCellLine = (
             cloneNumber:
                 cellLineNode.frontmatter.parental_line.frontmatter.clone_number,
             tagLocation:
-                cellLineNode.frontmatter.parental_line.frontmatter.tag_location,
+                multipleValues(cellLineNode.frontmatter.parental_line.frontmatter.tag_location),
             fluorescentTag:
-                cellLineNode.frontmatter.parental_line.frontmatter
-                    .fluorescent_tag,
+                multipleValues(cellLineNode.frontmatter.parental_line.frontmatter
+                    .fluorescent_tag),
             taggedGene: {
                 name: cellLineNode.frontmatter.parental_line.frontmatter.gene
                     .frontmatter.name,
@@ -57,8 +63,8 @@ export const convertFrontmatterToNormalCellLines = ({
         cellLineId: cellLineNode.frontmatter.cell_line_id,
         cloneNumber: cellLineNode.frontmatter.clone_number,
         alleleCount: cellLineNode.frontmatter.allele_count,
-        fluorescentTag: cellLineNode.frontmatter.fluorescent_tag,
-        tagLocation: cellLineNode.frontmatter.tag_location,
+        fluorescentTag: multipleValues(cellLineNode.frontmatter.fluorescent_tag),
+        tagLocation: multipleValues(cellLineNode.frontmatter.tag_location),
         parentalLine: cellLineNode.frontmatter.parental_line.frontmatter.name,
         protein: cellLineNode.frontmatter.gene.frontmatter.protein,
         taggedGene: {

--- a/src/component-queries/convert-data.ts
+++ b/src/component-queries/convert-data.ts
@@ -12,8 +12,6 @@ const extractGenes = (geneArray: { frontmatter: GeneFrontMatter }[] = []): Unpac
     if (!geneArray) return [];
 
     return geneArray
-        // TODO: check with scientists
-        // filter out null values, e.g. UBTF, CLYBL-dCas9-KRAB 
         .filter((gene) => gene && gene.frontmatter) 
         .map((gene) => ({
             name: gene.frontmatter.name,

--- a/src/component-queries/convert-data.ts
+++ b/src/component-queries/convert-data.ts
@@ -15,7 +15,13 @@ const multipleValues = (value: string | string[] | undefined): string => {
 
 
 const extractGenes = (geneArray: { frontmatter: GeneFrontMatter }[] = []): UnpackedGene[] => {
-    return geneArray.map((gene) => ({
+    if (!geneArray) return [];
+
+    return geneArray
+        // TODO: check with scientists
+        // filter out null values, e.g. UBTF, CLYBL-dCas9-KRAB 
+        .filter((gene) => gene && gene.frontmatter) 
+        .map((gene) => ({
             name: gene.frontmatter.name,
             symbol: gene.frontmatter.symbol,
             structure: gene.frontmatter.structure,

--- a/src/component-queries/types.ts
+++ b/src/component-queries/types.ts
@@ -22,7 +22,7 @@ export interface ParentalLineFrontmatter {
     thumbnail_image: any;
     gene: {
         frontmatter: GeneFrontMatter;
-    };
+    }[];
 }
 
 export interface NormalCellLineFrontmatter {
@@ -46,8 +46,8 @@ export interface NormalCellLineFrontmatter {
             symbol: string;
             structure: string;
         };
-    };
-}
+    }[];
+};
 
 export interface NormalCellLineNode {
     id: string;
@@ -157,7 +157,7 @@ export interface DiseaseFrontmatter {
     name: string;
     gene: {
         frontmatter: GeneFrontMatter;
-    };
+    }[];
     status: string;
     acknowledgements: { html: string };
 }
@@ -182,7 +182,7 @@ export interface UnpackedNormalCellLine extends UnpackedCellLineMainInfo {
     cloneNumber: number;
     tagLocation: string;
     fluorescentTag: string;
-    taggedGene: UnpackedGene;
+    taggedGene: UnpackedGene[];
     alleleCount: string;
     parentalLine: string;
     structure: string;
@@ -198,5 +198,5 @@ export interface UnpackedDiseaseCellLine extends UnpackedCellLineMainInfo {
     snp: string;
     clones: Clone[];
     parentalLine: ParentLine;
-    mutatedGene: UnpackedGene;
+    mutatedGene: UnpackedGene[];
 }

--- a/src/component-queries/types.ts
+++ b/src/component-queries/types.ts
@@ -180,8 +180,8 @@ export interface UnpackedCellLineMainInfo {
 }
 export interface UnpackedNormalCellLine extends UnpackedCellLineMainInfo {
     cloneNumber: number;
-    tagLocation: string;
-    fluorescentTag: string;
+    tagLocation: string[];
+    fluorescentTag: string[];
     taggedGene: UnpackedGene[];
     alleleCount: string;
     parentalLine: string;

--- a/src/component-queries/types.ts
+++ b/src/component-queries/types.ts
@@ -17,8 +17,8 @@ export interface ParentalLineFrontmatter {
     cell_line_id: number;
     clone_number: number;
     allele_count: string;
-    tag_location: string;
-    fluorescent_tag: string;
+    tag_location: string[];
+    fluorescent_tag: string[];
     thumbnail_image: any;
     gene: {
         frontmatter: GeneFrontMatter;
@@ -30,8 +30,8 @@ export interface NormalCellLineFrontmatter {
     cell_line_id: number;
     status: CellLineStatus;
     clone_number: number;
-    tag_location: string;
-    fluorescent_tag: string;
+    tag_location: string[];
+    fluorescent_tag: string[];
     allele_count: string;
     order_link: string;
     parental_line: {

--- a/src/components/CellLineTable/DiseaseTableColumns.tsx
+++ b/src/components/CellLineTable/DiseaseTableColumns.tsx
@@ -53,8 +53,17 @@ export const getDiseaseTableColumns = (
             key: "mutatedGene",
             dataIndex: "mutatedGene",
             responsive: mdBreakpoint,
-            render: (mutatedGene: UnpackedGene) => {
-                return <GeneDisplay gene={mutatedGene} />;
+            render: (mutatedGene: UnpackedGene[]) => {
+                return (
+                    <>
+                        {mutatedGene.map((gene, index) => (
+                            <GeneDisplay
+                                key={index}
+                                gene={gene}
+                            />
+                        ))}
+                    </>
+                ) 
             },
         },
         {

--- a/src/components/CellLineTable/NormalTableColumns.tsx
+++ b/src/components/CellLineTable/NormalTableColumns.tsx
@@ -13,6 +13,7 @@ import {
     certificateOfAnalysisColumn,
     obtainLineColumn,
 } from "./SharedColumns";
+import { render } from "react-dom";
 
 const { lastColumn } = require("../../style/table.module.css");
 
@@ -72,6 +73,9 @@ export const getNormalTableColumns = (
             key: "fluorescentTag",
             dataIndex: "fluorescentTag",
             responsive: mdBreakpoint,
+            render: (fluorescentTag: string[]) => {
+                return fluorescentTag?.join(" / ");
+            },
         },
         {
             title: "Tag Location",
@@ -79,6 +83,9 @@ export const getNormalTableColumns = (
             dataIndex: "tagLocation",
             className: inProgress ? "" : lastColumn,
             responsive: mdBreakpoint,
+            render: (tagLocation: string[]) => {
+                return tagLocation?.join(" / ");
+            },
         },
     ];
 

--- a/src/components/CellLineTable/NormalTableColumns.tsx
+++ b/src/components/CellLineTable/NormalTableColumns.tsx
@@ -34,8 +34,18 @@ export const getNormalTableColumns = (
             key: "taggedGene",
             dataIndex: "taggedGene",
             responsive: mdBreakpoint,
-            render: (taggedGene: UnpackedGene) => {
-                return <GeneDisplay gene={taggedGene} />;
+            render: (taggedGene: UnpackedGene[]) => {
+                return (
+                    <>
+                        {taggedGene.map((gene, index) => (
+                            <GeneDisplay
+                                key={index}
+                                gene={gene}
+                            />
+                        ))}
+                    </>
+                ) 
+                
             },
         },
         {

--- a/src/components/CellLineTable/NormalTableColumns.tsx
+++ b/src/components/CellLineTable/NormalTableColumns.tsx
@@ -13,7 +13,6 @@ import {
     certificateOfAnalysisColumn,
     obtainLineColumn,
 } from "./SharedColumns";
-import { render } from "react-dom";
 
 const { lastColumn } = require("../../style/table.module.css");
 

--- a/src/components/ImagesAndVideos.tsx
+++ b/src/components/ImagesAndVideos.tsx
@@ -26,7 +26,7 @@ interface ImagesAndVideosProps {
     videos?: any;
     geneSymbol: string;
     snp: string;
-    fluorescentTag: string;
+    fluorescentTag: string[];
     parentalGeneSymbol: string;
     alleleTag: string;
 }
@@ -34,7 +34,7 @@ interface ImagesAndVideosProps {
 const ImagesAndVideos: React.FC<ImagesAndVideosProps> = ({
     images = [],
     cellLineId,
-    fluorescentTag,
+    fluorescentTag = [],
     parentalGeneSymbol,
     alleleTag,
     geneSymbol,
@@ -62,7 +62,7 @@ const ImagesAndVideos: React.FC<ImagesAndVideosProps> = ({
     if (!imageData) {
         return null;
     }
-
+    // TODO: add separator for multiple fluorescent tags if any
     const title = (
         <Flex
             justify="space-between"

--- a/src/components/ImagesAndVideos.tsx
+++ b/src/components/ImagesAndVideos.tsx
@@ -62,7 +62,9 @@ const ImagesAndVideos: React.FC<ImagesAndVideosProps> = ({
     if (!imageData) {
         return null;
     }
-    // TODO: add separator for multiple fluorescent tags if any
+
+    const firstTag = fluorescentTag.length > 0 ? fluorescentTag[0] : "";
+
     const title = (
         <Flex
             justify="space-between"
@@ -72,7 +74,7 @@ const ImagesAndVideos: React.FC<ImagesAndVideosProps> = ({
             <div className={titleSection}>
                 <h3 className={mainTitle}>{formatCellLineId(cellLineId)}</h3>
                 <span className={subtitle}>
-                    {geneSymbol} in WTC-{fluorescentTag}-{parentalGeneSymbol} (
+                    {geneSymbol} in WTC-{firstTag}-{parentalGeneSymbol} (
                     {alleleTag}-allelic tag)
                 </span>
             </div>

--- a/src/components/ParentalLineModal.tsx
+++ b/src/components/ParentalLineModal.tsx
@@ -22,7 +22,7 @@ interface ParentalLineModalProps {
     formattedId: string;
     cloneNumber: number;
     status: string;
-    taggedGene: UnpackedGene;
+    taggedGene: UnpackedGene[];
     tagLocation: string;
     fluorescentTag: string;
 }
@@ -50,7 +50,8 @@ const ParentalLineModal = (props: ParentalLineModalProps) => {
     if (props.status === "coming soon") {
         return <>{props.formattedId}</>;
     }
-    const { symbol, name } = props.taggedGene;
+    
+    const { symbol, name } = props.taggedGene[0];
     const { fluorescentTag, tagLocation } = props;
     const parentalLineItems = [
         {

--- a/src/components/ParentalLineModal.tsx
+++ b/src/components/ParentalLineModal.tsx
@@ -23,8 +23,8 @@ interface ParentalLineModalProps {
     cloneNumber: number;
     status: string;
     taggedGene: UnpackedGene[];
-    tagLocation: string;
-    fluorescentTag: string;
+    tagLocation: string[];
+    fluorescentTag: string[];
 }
 const ParentalLineModal = (props: ParentalLineModalProps) => {
     const [isModalOpen, setIsModalOpen] = useState(false);
@@ -52,7 +52,8 @@ const ParentalLineModal = (props: ParentalLineModalProps) => {
     }
     
     const { symbol, name } = props.taggedGene[0];
-    const { fluorescentTag, tagLocation } = props;
+    const fluorescentTag  = props.fluorescentTag[0];
+    const tagLocation = props.tagLocation[0];
     const parentalLineItems = [
         {
             key: "1",

--- a/src/components/SubPage/convert-data.ts
+++ b/src/components/SubPage/convert-data.ts
@@ -99,7 +99,7 @@ export const unpackDiseaseFrontmatterForSubpage = (
     const parentalLineData = cellLineNode.frontmatter.parental_line.frontmatter;
 
     const { name: geneName, symbol: geneSymbol } =
-        cellLineNode.frontmatter.disease.frontmatter.gene.frontmatter;
+        cellLineNode.frontmatter.disease.frontmatter.gene[0].frontmatter;
 
     const editingDesign = unpackEditingDesignData(
         cellLineNode.frontmatter.editing_design
@@ -122,7 +122,7 @@ export const unpackDiseaseFrontmatterForSubpage = (
         diseaseName: cellLineNode.frontmatter.disease.frontmatter.name,
         snp: cellLineNode.frontmatter.snp,
         parentalLine: parentalLineData,
-        parentalLineGene: parentalLineData.gene.frontmatter,
+        parentalLineGene: parentalLineData.gene[0].frontmatter,
         clones: cellLineNode.frontmatter.clones, // TODO: unpack this into only data needed for card
         imagesAndVideos: cellLineNode.frontmatter.images_and_videos,
         editingDesign: editingDesign,

--- a/src/pages/cell-line/AICS-00/index.md
+++ b/src/pages/cell-line/AICS-00/index.md
@@ -4,5 +4,5 @@ cell_line_id: 0
 name: WTC
 status: released
 date: 2024-02-27T23:13:35.356Z
-parental_line: ""
+parental_line: 0
 ---

--- a/src/pages/cell-line/AICS-10-55/index.md
+++ b/src/pages/cell-line/AICS-10-55/index.md
@@ -5,7 +5,8 @@ status: released
 clone_number: 55
 allele_count: mono
 parental_line: 0
-gene: SEC61B
+gene:
+  - SEC61B
 tag_location:
   - N-terminus
 fluorescent_tag:

--- a/src/pages/cell-line/AICS-102/index.md
+++ b/src/pages/cell-line/AICS-102/index.md
@@ -5,7 +5,8 @@ status: in progress
 date: 2025-02-05T17:41:29.111Z
 clone_number: 330
 parental_line: 0
-gene: AAVS1
+gene: 
+  - AAVS1
 allele_count: mono
 fluorescent_tag:
   - mTagRFP-T

--- a/src/pages/cell-line/AICS-11-27/index.md
+++ b/src/pages/cell-line/AICS-11-27/index.md
@@ -5,7 +5,8 @@ status: released
 clone_number: 27
 allele_count: mono
 parental_line: 0
-gene: TOMM20
+gene:
+  - TOMM20
 tag_location:
   - C-terminus
 fluorescent_tag:

--- a/src/pages/cell-line/AICS-114-32/index.md
+++ b/src/pages/cell-line/AICS-114-32/index.md
@@ -5,7 +5,8 @@ status: released
 clone_number: 32
 allele_count: bi
 parental_line: 0
-gene: CDH1
+gene:
+  - CDH1
 tag_location:
   - C-terminus
 fluorescent_tag:

--- a/src/pages/cell-line/AICS-114-35/index.md
+++ b/src/pages/cell-line/AICS-114-35/index.md
@@ -5,7 +5,8 @@ status: released
 clone_number: 35
 allele_count: mono
 parental_line: 0
-gene: CDH1
+gene:
+  - CDH1
 tag_location:
   - C-terminus
 fluorescent_tag:

--- a/src/pages/cell-line/AICS-12-105/index.md
+++ b/src/pages/cell-line/AICS-12-105/index.md
@@ -5,7 +5,8 @@ status: released
 clone_number: 105
 allele_count: mono
 parental_line: 0
-gene: TUBA1B
+gene:
+  - TUBA1B
 tag_location:
   - N-terminus
 fluorescent_tag:

--- a/src/pages/cell-line/AICS-122-in-progress/index.md
+++ b/src/pages/cell-line/AICS-122-in-progress/index.md
@@ -5,7 +5,8 @@ status: in progress
 clone_number: 
 allele_count: 
 parental_line: 0
-gene: EOMES
+gene:
+  - EOMES
 tag_location:
   - C-terminus
 fluorescent_tag:

--- a/src/pages/cell-line/AICS-126-41/index.md
+++ b/src/pages/cell-line/AICS-126-41/index.md
@@ -5,7 +5,8 @@ status: released
 clone_number: 41
 allele_count: bi
 parental_line: 0
-gene: CDH5
+gene:
+  - CDH5
 tag_location:
   - C-terminus
 fluorescent_tag:

--- a/src/pages/cell-line/AICS-126-68/index.md
+++ b/src/pages/cell-line/AICS-126-68/index.md
@@ -5,7 +5,8 @@ status: released
 clone_number: 68
 allele_count: mono
 parental_line: 0
-gene: CDH5
+gene:
+  - CDH5
 tag_location:
   - C-terminus
 fluorescent_tag:

--- a/src/pages/cell-line/AICS-13-210/index.md
+++ b/src/pages/cell-line/AICS-13-210/index.md
@@ -6,7 +6,8 @@ thumbnail_image: aics-13.jpg
 clone_number: 210
 allele_count: mono
 parental_line: 0
-gene: LMNB1
+gene:
+  - LMNB1
 tag_location:
   - N-terminus
 fluorescent_tag:

--- a/src/pages/cell-line/AICS-14-6/index.md
+++ b/src/pages/cell-line/AICS-14-6/index.md
@@ -5,7 +5,8 @@ status: released
 clone_number: 6
 allele_count: mono
 parental_line: 0
-gene: FBL
+gene:
+  - FBL
 tag_location:
   - C-terminus
 fluorescent_tag:

--- a/src/pages/cell-line/AICS-16-184/index.md
+++ b/src/pages/cell-line/AICS-16-184/index.md
@@ -5,7 +5,8 @@ status: released
 clone_number: 184
 allele_count: mono
 parental_line: 0
-gene: ACTB
+gene:
+  - ACTB
 tag_location:
   - N-terminus
 fluorescent_tag:

--- a/src/pages/cell-line/AICS-17-65/index.md
+++ b/src/pages/cell-line/AICS-17-65/index.md
@@ -5,7 +5,8 @@ status: released
 clone_number: 65
 allele_count: mono
 parental_line: 0
-gene: DSP
+gene:
+  - DSP
 tag_location:
   - C-terminus
 fluorescent_tag:

--- a/src/pages/cell-line/AICS-22-37/index.md
+++ b/src/pages/cell-line/AICS-22-37/index.md
@@ -5,7 +5,8 @@ status: released
 clone_number: 37
 allele_count: mono
 parental_line: 0
-gene: LAMP1
+gene:
+  - LAMP1
 tag_location:
   - C-terminus
 fluorescent_tag:

--- a/src/pages/cell-line/AICS-23-20/index.md
+++ b/src/pages/cell-line/AICS-23-20/index.md
@@ -5,7 +5,8 @@ status: released
 clone_number: 20
 allele_count: mono
 parental_line: 0
-gene: TJP1
+gene:
+  - TJP1
 tag_location:
   - N-terminus
 fluorescent_tag:

--- a/src/pages/cell-line/AICS-24-80/index.md
+++ b/src/pages/cell-line/AICS-24-80/index.md
@@ -5,7 +5,8 @@ status: released
 clone_number: 80
 allele_count: mono
 parental_line: 0
-gene: MYH10
+gene:
+  - MYH10
 tag_location:
   - N-terminus
 fluorescent_tag:

--- a/src/pages/cell-line/AICS-25-1/index.md
+++ b/src/pages/cell-line/AICS-25-1/index.md
@@ -5,7 +5,8 @@ status: released
 clone_number: 1
 allele_count: mono
 parental_line: 0
-gene: ST6GAL1
+gene:
+  - ST6GAL1
 tag_location:
   - C-terminus
 fluorescent_tag:

--- a/src/pages/cell-line/AICS-25-44/index.md
+++ b/src/pages/cell-line/AICS-25-44/index.md
@@ -5,7 +5,8 @@ status: released
 clone_number: 44
 allele_count: bi
 parental_line: 0
-gene: ST6GAL1
+gene:
+  - ST6GAL1
 tag_location:
   - C-terminus
 fluorescent_tag:

--- a/src/pages/cell-line/AICS-30-22/index.md
+++ b/src/pages/cell-line/AICS-30-22/index.md
@@ -5,7 +5,8 @@ status: released
 clone_number: 22
 allele_count: mono
 parental_line: 0
-gene: MAP1LC3B
+gene:
+  - MAP1LC3B
 tag_location:
   - N-terminus
 fluorescent_tag:

--- a/src/pages/cell-line/AICS-31-35/index.md
+++ b/src/pages/cell-line/AICS-31-35/index.md
@@ -5,7 +5,8 @@ status: released
 clone_number: 35
 allele_count: mono
 parental_line: 0
-gene: TUBA1B
+gene:
+  - TUBA1B
 tag_location:
   - N-terminus
 fluorescent_tag:

--- a/src/pages/cell-line/AICS-32-19/index.md
+++ b/src/pages/cell-line/AICS-32-19/index.md
@@ -5,7 +5,8 @@ status: released
 clone_number: 19
 allele_count: mono
 parental_line: 0
-gene: CETN2
+gene:
+  - CETN2
 tag_location:
   - N-terminus
 fluorescent_tag:

--- a/src/pages/cell-line/AICS-33-115/index.md
+++ b/src/pages/cell-line/AICS-33-115/index.md
@@ -5,7 +5,8 @@ status: released
 clone_number: 115
 allele_count: mono
 parental_line: 0
-gene: SLC25A17
+gene:
+  - SLC25A17
 tag_location:
   - C-terminus
 fluorescent_tag:

--- a/src/pages/cell-line/AICS-34-62/index.md
+++ b/src/pages/cell-line/AICS-34-62/index.md
@@ -5,7 +5,8 @@ status: released
 clone_number: 62
 allele_count: mono
 parental_line: 0
-gene: LMNB1
+gene:
+  - LMNB1
 tag_location:
   - N-terminus
 fluorescent_tag:

--- a/src/pages/cell-line/AICS-36-28/index.md
+++ b/src/pages/cell-line/AICS-36-28/index.md
@@ -5,7 +5,8 @@ status: released
 clone_number: 28
 allele_count: mono
 parental_line: 0
-gene: AAVS1
+gene:
+  - AAVS1
 tag_location:
   - NA
 fluorescent_tag:

--- a/src/pages/cell-line/AICS-36-6/index.md
+++ b/src/pages/cell-line/AICS-36-6/index.md
@@ -5,7 +5,8 @@ status: released
 clone_number: 6
 allele_count: mono
 parental_line: 0
-gene: AAVS1
+gene:
+  - AAVS1
 tag_location:
   - NA
 fluorescent_tag:

--- a/src/pages/cell-line/AICS-37-172/index.md
+++ b/src/pages/cell-line/AICS-37-172/index.md
@@ -5,7 +5,8 @@ status: released
 clone_number: 172
 allele_count: mono
 parental_line: 0
-gene: TNNI1
+gene:
+  - TNNI1
 tag_location:
   - C-terminus
 fluorescent_tag:

--- a/src/pages/cell-line/AICS-40-13/index.md
+++ b/src/pages/cell-line/AICS-40-13/index.md
@@ -5,7 +5,8 @@ status: released
 clone_number: 13
 allele_count: mono
 parental_line: 0
-gene: RAB5A
+gene:
+  - RAB5A
 tag_location:
   - N-terminus
 fluorescent_tag:

--- a/src/pages/cell-line/AICS-40-35/index.md
+++ b/src/pages/cell-line/AICS-40-35/index.md
@@ -5,7 +5,8 @@ status: released
 clone_number: 35
 allele_count: bi
 parental_line: 0
-gene: RAB5A
+gene:
+  - RAB5A
 tag_location:
   - N-terminus
 fluorescent_tag:

--- a/src/pages/cell-line/AICS-46-51/index.md
+++ b/src/pages/cell-line/AICS-46-51/index.md
@@ -5,7 +5,8 @@ status: released
 clone_number: 51
 allele_count: mono
 parental_line: 0
-gene: ATP2A2
+gene:
+  - ATP2A2
 tag_location:
   - N-terminus
 fluorescent_tag:

--- a/src/pages/cell-line/AICS-48-39/index.md
+++ b/src/pages/cell-line/AICS-48-39/index.md
@@ -5,7 +5,8 @@ status: released
 clone_number: 39
 allele_count: mono
 parental_line: 0
-gene: TTN
+gene:
+  - TTN
 tag_location:
   - C-terminus
 fluorescent_tag:

--- a/src/pages/cell-line/AICS-5-50/index.md
+++ b/src/pages/cell-line/AICS-5-50/index.md
@@ -5,7 +5,8 @@ status: released
 clone_number: 50
 allele_count: mono
 parental_line: 0
-gene: PXN
+gene:
+  - PXN
 tag_location:
   - C-terminus
 fluorescent_tag:

--- a/src/pages/cell-line/AICS-52-3/index.md
+++ b/src/pages/cell-line/AICS-52-3/index.md
@@ -5,7 +5,8 @@ status: released
 clone_number: 3
 allele_count: mono
 parental_line: 0
-gene: MYL7
+gene:
+  - MYL7
 tag_location:
   - C-terminus
 fluorescent_tag:

--- a/src/pages/cell-line/AICS-53-16/index.md
+++ b/src/pages/cell-line/AICS-53-16/index.md
@@ -5,7 +5,8 @@ status: released
 clone_number: 16
 allele_count: mono
 parental_line: 0
-gene: GJA1
+gene:
+  - GJA1
 tag_location:
   - C-terminus
 fluorescent_tag:

--- a/src/pages/cell-line/AICS-54-91/index.md
+++ b/src/pages/cell-line/AICS-54-91/index.md
@@ -5,7 +5,8 @@ status: released
 clone_number: 91
 allele_count: mono
 parental_line: 0
-gene: AAVS1
+gene:
+  - AAVS1
 tag_location:
   - NA
 fluorescent_tag:

--- a/src/pages/cell-line/AICS-57-50/index.md
+++ b/src/pages/cell-line/AICS-57-50/index.md
@@ -5,7 +5,8 @@ status: released
 clone_number: 50
 allele_count: mono
 parental_line: 0
-gene: NPM1
+gene:
+  - NPM1
 tag_location:
   - C-terminus
 fluorescent_tag:

--- a/src/pages/cell-line/AICS-58-67/index.md
+++ b/src/pages/cell-line/AICS-58-67/index.md
@@ -5,7 +5,8 @@ status: released
 clone_number: 67
 allele_count: mono
 parental_line: 0
-gene: CTNNB1
+gene:
+  - CTNNB1
 tag_location:
   - N-terminus
 fluorescent_tag:

--- a/src/pages/cell-line/AICS-59-36/index.md
+++ b/src/pages/cell-line/AICS-59-36/index.md
@@ -1,0 +1,29 @@
+---
+templateKey: cell-line
+cell_line_id: 59
+status: released
+clone_number: 36
+allele_count: mono
+parental_line: 0
+gene:
+  - SEC61B
+  - LMNB1
+tag_location:
+  - N-terminus
+  - N-terminus
+fluorescent_tag:
+  - mEGFP
+  - mTagRFP-T
+order_link: https://www.coriell.org/0/Sections/Search/Sample_Detail.aspx?Ref=AICS-0059-036&PgId=166
+cofa: https://www.coriell.org/0/PDF/Allen/ipsc/AICS-0059-036_CofA.pdf
+donor_plasmid: https://www.addgene.org/The_Allen_Institute_for_Cell_Science/
+eu_hpsc_reg: https://hpscreg.eu/cell-line/UCSFi001-A-33
+images_and_videos:
+  videos:
+    - video: https://player.vimeo.com/video/307597511
+      caption: "Z-stack of a live hiPS cell colony expressing mEGFP-tagged Sec61 beta and mTagRFP-T-tagged lamin B1. Panels show individual channels for Sec61 beta (left) and lamin B1 (middle) and the overlay of the two (right). Cells were imaged in 3D on a spinning-disk confocal microscope. Movie starts at the bottom of the cells and ends at the top. Scale bar, 5µm."
+    - video: https://player.vimeo.com/video/307168127
+      caption: "Time-lapse movie of a live hiPS cell colony expressing mEGFP-tagged Sec61 beta and mTagRFP-T-tagged lamin B1. Panels show individual channels for Sec61 beta (left) and lamin B1 (middle) and the overlay of the two (right). A single, mid-level plane was imaged on a spinning-disk confocal microscope every 5 min. Movie plays at 3000x real time. Scale bar, 5 µm."
+    - video: https://player.vimeo.com/video/307167915
+      caption: "Time-lapse movie of a live hiPS cell colony expressing mEGFP-tagged Sec61 beta and mTagRFP-T-tagged lamin B1. Panels show individual channels for Sec61 beta (left) and lamin B1 (middle) and the overlay of the two (right). Cells were imaged in 3D on a spinning-disk confocal microscope every 5 min. A single mid-level z-section is shown. Movie plays at 1200x real time. Scale bar, 20 µm."
+---

--- a/src/pages/cell-line/AICS-60-27/index.md
+++ b/src/pages/cell-line/AICS-60-27/index.md
@@ -5,7 +5,8 @@ status: released
 clone_number: 27
 allele_count: mono
 parental_line: 0
-gene: MYL2
+gene:
+  - MYL2
 tag_location:
   - C-terminus
 fluorescent_tag:

--- a/src/pages/cell-line/AICS-61-36/index.md
+++ b/src/pages/cell-line/AICS-61-36/index.md
@@ -5,7 +5,8 @@ status: released
 clone_number: 36
 allele_count: mono
 parental_line: 0
-gene: HIST1H2BJ
+gene:
+  - HIST1H2BJ
 tag_location:
   - C-terminus
 fluorescent_tag:

--- a/src/pages/cell-line/AICS-63-96/index.md
+++ b/src/pages/cell-line/AICS-63-96/index.md
@@ -5,7 +5,8 @@ status: released
 clone_number: 96
 allele_count: mono
 parental_line: 0
-gene: DMD
+gene:
+  - DMD
 tag_location:
   - C-terminus
 fluorescent_tag:

--- a/src/pages/cell-line/AICS-68-9/index.md
+++ b/src/pages/cell-line/AICS-68-9/index.md
@@ -5,7 +5,8 @@ status: released
 clone_number: 9
 allele_count: mono
 parental_line: 0
-gene: SMC1A
+gene:
+  - SMC1A
 tag_location:
   - C-terminus
 fluorescent_tag:

--- a/src/pages/cell-line/AICS-69-88/index.md
+++ b/src/pages/cell-line/AICS-69-88/index.md
@@ -5,7 +5,8 @@ status: released
 clone_number: 88
 allele_count: mono
 parental_line: 0
-gene: NUP153
+gene:
+  - NUP153
 tag_location:
   - N-terminus
 fluorescent_tag:

--- a/src/pages/cell-line/AICS-70-in-progress/index.md
+++ b/src/pages/cell-line/AICS-70-in-progress/index.md
@@ -5,7 +5,8 @@ status: in progress
 clone_number: 
 allele_count: 
 parental_line: 0
-gene: CBX1
+gene:
+  - CBX1
 tag_location:
   - N-terminus
 fluorescent_tag:

--- a/src/pages/cell-line/AICS-74-26/index.md
+++ b/src/pages/cell-line/AICS-74-26/index.md
@@ -5,7 +5,8 @@ status: released
 clone_number: 26
 allele_count: mono
 parental_line: 0
-gene: SOX2
+gene:
+  - SOX2
 tag_location:
   - C-terminus
 fluorescent_tag:

--- a/src/pages/cell-line/AICS-75-85/index.md
+++ b/src/pages/cell-line/AICS-75-85/index.md
@@ -6,7 +6,8 @@ thumbnail_image: 20181023_m02_001_s13_cl85_cropped_scalebar20_withinset_rgb.jpg
 clone_number: 85
 allele_count: mono
 parental_line: 0
-gene: ACTN2
+gene:
+  - ACTN2
 tag_location:
   - C-terminus
 fluorescent_tag:

--- a/src/pages/cell-line/AICS-78-79/index.md
+++ b/src/pages/cell-line/AICS-78-79/index.md
@@ -1,0 +1,23 @@
+---
+templateKey: cell-line
+cell_line_id: 78
+status: released
+clone_number: 79
+allele_count: mono
+parental_line: 0
+gene:
+  - TOMM20
+  - TUBA1B
+tag_location:
+  - C-terminus
+  - N-terminus
+fluorescent_tag:
+  - mEGFP
+  - mTagRFP-T
+order_link: https://www.coriell.org/0/Sections/Search/Sample_Detail.aspx?Ref=AICS-0078-079&PgId=166
+cofa: https://www.coriell.org/0/PDF/Allen/ipsc/AICS-0078-079_CofA.pdf
+donor_plasmid: https://www.addgene.org/The_Allen_Institute_for_Cell_Science/
+eu_hpsc_reg: https://hpscreg.eu/cell-line/UCSFi001-A-55
+images_and_videos:
+  videos:
+---

--- a/src/pages/cell-line/AICS-80-69/index.md
+++ b/src/pages/cell-line/AICS-80-69/index.md
@@ -5,7 +5,8 @@ status: released
 clone_number: 69
 allele_count: mono
 parental_line: 0
-gene: FUS
+gene:
+  - FUS
 tag_location:
   - C-terminus
 fluorescent_tag:

--- a/src/pages/cell-line/AICS-82-1/index.md
+++ b/src/pages/cell-line/AICS-82-1/index.md
@@ -5,7 +5,8 @@ status: released
 clone_number: 1
 allele_count: mono
 parental_line: 0
-gene: G3BP1
+gene:
+  - G3BP1
 tag_location:
   - N-terminus
 fluorescent_tag:

--- a/src/pages/cell-line/AICS-83-124/index.md
+++ b/src/pages/cell-line/AICS-83-124/index.md
@@ -5,7 +5,8 @@ status: released
 clone_number: 124
 allele_count: mono
 parental_line: 0
-gene: DCP1A
+gene:
+  - DCP1A
 tag_location:
   - N-terminus
 fluorescent_tag:

--- a/src/pages/cell-line/AICS-83-5/index.md
+++ b/src/pages/cell-line/AICS-83-5/index.md
@@ -5,7 +5,8 @@ status: released
 clone_number: 5
 allele_count: bi
 parental_line: 0
-gene: DCP1A
+gene:
+  - DCP1A
 tag_location:
   - N-terminus
 fluorescent_tag:

--- a/src/pages/cell-line/AICS-84-18/index.md
+++ b/src/pages/cell-line/AICS-84-18/index.md
@@ -1,0 +1,29 @@
+---
+templateKey: cell-line
+cell_line_id: 84
+status: released
+clone_number: 18
+allele_count: mono
+parental_line: 0
+gene:
+  - FBL
+  - NPM1
+tag_location:
+  - C-terminus
+  - C-terminus
+fluorescent_tag:
+  - mEGFP
+  - mTagRFP-T
+order_link: https://www.coriell.org/0/Sections/Search/Sample_Detail.aspx?Ref=AICS-0084-018&PgId=166
+cofa: https://www.coriell.org/0/PDF/Allen/ipsc/AICS-0084-018_CofA.pdf
+donor_plasmid: https://www.addgene.org/The_Allen_Institute_for_Cell_Science/
+eu_hpsc_reg: https://hpscreg.eu/cell-line/UCSFi001-A-38
+images_and_videos:
+  videos:
+    - video: https://player.vimeo.com/video/333852568
+      caption: "Z-stack of live hiPS cell colony expressing mEGFP-tagged fibrillarin and mTagRFP-T-tagged nucleophosmin. Panels show individual channels for fibrillarin (left) and nucleophosmin (middle) and the overlay of the two (right). Cells were imaged in 3D on a spinning-disk confocal microscope. Movie starts at the bottom of the cells and ends at the top. Scale bar, 5µm."
+    - video: https://player.vimeo.com/video/333852580
+      caption: "Time-lapse movie of live hiPS cell colony expressing mEGFP-tagged fibrillarin and mTagRFP-T-tagged nucleophosmin. The region bounded by a dashed line is shown at the same scale with enhanced contrast to highlight changes in localization during mitosis. A single, mid-level plane of the cells was imaged every 3 min on a spinning-disk confocal microscope. Movie plays at 900x real time. Scale bar, 5 µm."
+    - video: https://player.vimeo.com/video/333852631
+      caption: "Time-lapse movie of live hiPS cell colony expressing mEGFP-tagged fibrillarin and mTagRFP-T-tagged nucleophosmin. Panels show individual channels for fibrillarin (left) and nucleophosmin (middle) and the overlay of the two (right). Cells were imaged in 3D on a spinning-disk confocal microscope every 3 min. Frames are maximum intensity z-projections through the entire volume of the cell. Movie plays at 1800x real time. Scale bar, 20 µm."
+---

--- a/src/pages/cell-line/AICS-86-147/index.md
+++ b/src/pages/cell-line/AICS-86-147/index.md
@@ -1,0 +1,32 @@
+---
+templateKey: cell-line
+cell_line_id: 86
+status: released
+clone_number: 147
+allele_count: mono
+parental_line: 0
+gene:
+  - FBL
+  - NPM1
+  - UBTF
+tag_location:
+  - C-terminus
+  - C-terminus
+  - N-terminus
+fluorescent_tag:
+  - mEGFP
+  - mTagRFP-T
+  - HaloTag
+order_link: https://www.coriell.org/0/Sections/Search/Sample_Detail.aspx?Ref=AICS-0086-147&PgId=166
+cofa: https://www.coriell.org/0/PDF/Allen/ipsc/AICS-0086-147_CofA.pdf
+donor_plasmid: https://www.addgene.org/133963/
+eu_hpsc_reg: https://hpscreg.eu/cell-line/UCSFi001-A-42
+images_and_videos:
+  videos:
+    - video: https://player.vimeo.com/video/442124590
+      caption: "Z-stack of live hiPS cell colony expressing mEGFP-tagged fibrillarin, mTagRFP-T-tagged nucleophosmin, and HaloTag-tagged nucleolar transcription factor UBF visualized with ligand Janelia Fluor 646 (Promega). Panels show individual channels for fibrillarin, nucleolar transcription factor UBF, nucleophosmin, and an overlay of the three (counterclockwise from top right). Cells were imaged in 3D on a spinning-disk confocal microscope. Movie starts at the bottom of the cells and ends at the top. Scale bar, 5 µm."
+    - video: https://player.vimeo.com/video/442123253
+      caption: "Time-lapse movie of live hiPS cell colony expressing mEGFP-tagged fibrillarin, mTagRFP-T-tagged nucleophosmin, and HaloTag-tagged nucleolar transcription factor UBF visualized with ligand Janelia Fluor 646 (Promega). Panels show individual channels for nucleolar transcription factor UBF, fibrillarin, nucleophosmin, and an overlay of the three (left to right). Boxed regions in top row are shown enlarged in the bottom row with increased brightness.  Cells were imaged in 3D on a spinning-disk confocal microscope every 3 min. A single mid-level plane is shown. Movie plays at 900x real time. Scale bar, 5 µm."
+    - video: https://player.vimeo.com/video/442124499
+      caption: "Time-lapse movie of live hiPS cell colony expressing mEGFP-tagged fibrillarin (pseudocolored in magenta), mTagRFP-T-tagged nucleophosmin (pseudocolored in cyan), and HaloTag-tagged nucleolar transcription factor UBF visualized with ligand Janelia Fluor 646 (Promega) (pseudocolored in yellow); overlay of channels appears white where proteins are colocalized. Cells were imaged in 3D on a spinning-disk confocal microscope every 3 min. A single mid-level plane is shown. Movie plays at 1800x real time. Scale bar, 20 µm."
+---

--- a/src/pages/cell-line/AICS-87-31/index.md
+++ b/src/pages/cell-line/AICS-87-31/index.md
@@ -5,7 +5,8 @@ status: released
 clone_number: 31
 allele_count: mono
 parental_line: 0
-gene: TFAM
+gene:
+  - TFAM
 tag_location:
   - C-terminus
 fluorescent_tag:

--- a/src/pages/cell-line/AICS-88-83/index.md
+++ b/src/pages/cell-line/AICS-88-83/index.md
@@ -5,7 +5,8 @@ status: released
 clone_number: 83
 allele_count: mono
 parental_line: 0
-gene: PCNA
+gene:
+  - PCNA
 tag_location:
   - N-terminus
 fluorescent_tag:

--- a/src/pages/cell-line/AICS-89-61/index.md
+++ b/src/pages/cell-line/AICS-89-61/index.md
@@ -1,0 +1,32 @@
+---
+templateKey: cell-line
+cell_line_id: 89
+status: released
+clone_number: 61
+allele_count: mono
+parental_line: 0
+gene:
+  - FBL
+  - NPM1
+  - CLYBL-dCas9-KRAB
+tag_location:
+  - C-terminus
+  - C-terminus
+  - NA
+fluorescent_tag:
+  - mEGFP
+  - mTagRFP-T
+  - TagBFP
+order_link: https://www.coriell.org/0/Sections/Search/Sample_Detail.aspx?Ref=AICS-0089-061&PgId=166
+cofa: https://www.coriell.org/0/PDF/Allen/ipsc/AICS-0089-061_CofA.pdf
+donor_plasmid: https://www.addgene.org/The_Allen_Institute_for_Cell_Science/
+eu_hpsc_reg: https://hpscreg.eu/cell-line/UCSFi001-A-39
+images_and_videos:
+  videos:
+    - video: https://player.vimeo.com/video/442183009
+      caption: "Z-stack of live hiPS cell colony expressing mEGFP-tagged fibrillarin, mTagRFP-T-tagged nucleophosmin, and TagBFP-tagged dCas9-KRAB. Panels show individual channels for fibrillarin, nucleophosmin, and the overlay of the two (left to right). TagBFP-tagged dCas9-KRAB is not shown here because it was used to identify dCas9-KRAB expressing cells and not to highlight a structure (see single z-slice image for its expression pattern). Cells were imaged in 3D on a spinning-disk confocal microscope. Movie starts at the bottom of the cells and ends at the top. Scale bar, 5µm."
+    - video: https://player.vimeo.com/video/442182527
+      caption: "Time-lapse movie of live hiPS cell colony expressing mEGFP-tagged fibrillarin, mTagRFP-T-tagged nucleophosmin, and TagBFP-tagged dCas9-KRAB. Panels show individual channels for fibrillarin, nucleophosmin, and the overlay of the two (left to right). TagBFP-tagged dCas9-KRAB is not shown here because it was used to identify dCas9-KRAB expressing cells and not to highlight a structure (see single z-slice image for its expression pattern). The regions bounded by a dashed line are shown at the same scale with increased brightness to highlight changes in localization during mitosis. A single, mid-level plane of the cells was imaged every 3 min on a spinning-disk confocal microscope. Movie plays at 900x real time. Scale bar, 5 µm."
+    - video: https://player.vimeo.com/video/442182868
+      caption: "Time-lapse movie of live hiPS cell colony expressing mEGFP-tagged fibrillarin, mTagRFP-T-tagged nucleophosmin, and TagBFP-tagged dCas9-KRAB. Panels show individual channels for fibrillarin, nucleophosmin, and the overlay of the two (left to right). TagBFP-tagged dCas9-KRAB is not shown here because it was used to identify dCas9-KRAB expressing cells and not to highlight a structure (see single z-slice image for its expression pattern). Cells were imaged in 3D on a spinning-disk confocal microscope every 3 min. A single mid-level plane is shown. Movie plays at 1800x real time. Scale bar, 20 µm."
+---

--- a/src/pages/cell-line/AICS-90-391/index.md
+++ b/src/pages/cell-line/AICS-90-391/index.md
@@ -5,7 +5,8 @@ status: released
 clone_number: 391
 allele_count: mono
 parental_line: 0
-gene: CLYBL safe harbor
+gene:
+  - CLYBL safe harbor
 tag_location:
   - NA
 fluorescent_tag:

--- a/src/pages/cell-line/AICS-93-25/index.md
+++ b/src/pages/cell-line/AICS-93-25/index.md
@@ -5,7 +5,8 @@ status: released
 clone_number: 25
 allele_count: mono
 parental_line: 0
-gene: TERF2
+gene:
+  - TERF2
 tag_location:
   - N-terminus
 fluorescent_tag:

--- a/src/pages/cell-line/AICS-94-24/index.md
+++ b/src/pages/cell-line/AICS-94-24/index.md
@@ -5,7 +5,8 @@ status: released
 clone_number: 24
 allele_count: mono
 parental_line: 0
-gene: SON
+gene:
+  - SON
 tag_location:
   - N-terminus
 fluorescent_tag:

--- a/src/pages/cell-line/AICS-95-18/index.md
+++ b/src/pages/cell-line/AICS-95-18/index.md
@@ -5,7 +5,8 @@ status: released
 clone_number: 18
 allele_count: mono
 parental_line: 0
-gene: EZH2
+gene:
+  - EZH2
 tag_location:
   - N-terminus
 fluorescent_tag:

--- a/src/pages/cell-line/AICS-96-74/index.md
+++ b/src/pages/cell-line/AICS-96-74/index.md
@@ -5,7 +5,8 @@ status: released
 clone_number: 74
 allele_count: mono
 parental_line: 0
-gene: POLR2A
+gene:
+  - POLR2A
 tag_location:
   - N-terminus
 fluorescent_tag:

--- a/src/pages/cell-line/AICS-99-20/index.md
+++ b/src/pages/cell-line/AICS-99-20/index.md
@@ -5,7 +5,8 @@ status: released
 clone_number: 20
 allele_count: mono
 parental_line: 0
-gene: CTCF
+gene:
+  - CTCF
 tag_location:
   - N-terminus
 fluorescent_tag:

--- a/src/pages/diseases/cardiomyopathy-skeletal.md
+++ b/src/pages/diseases/cardiomyopathy-skeletal.md
@@ -1,7 +1,8 @@
 ---
 templateKey: disease
 name: Skeletal Myopathy
-gene: MYH3
+gene: 
+  - MYH3
 status: Available
 acknowledgements: These lines were generated at Allen Institute and released to
   a group of collaborators to perform skeletal differentiation. We would like to

--- a/src/pages/diseases/cardiomyopathy.md
+++ b/src/pages/diseases/cardiomyopathy.md
@@ -1,7 +1,8 @@
 ---
 templateKey: disease
 name: Cardiomyopathy
-gene: MYH7
+gene: 
+  - MYH7
 status: Available
 acknowledgements: "These cell lines were generated at Allen Institute and
   released to a group of collaborators to perform preliminary studies. We would

--- a/src/pages/diseases/laminopathy.md
+++ b/src/pages/diseases/laminopathy.md
@@ -1,7 +1,8 @@
 ---
 templateKey: disease
 name: Laminopathy
-gene: LMNA
+gene: 
+  - LMNA
 status: Available
 acknowledgements: These lines were generated at Allen Institute and released to
   a group of collaborators to perform preliminary studies. We would like to

--- a/src/pages/gene-names/clybl-dcas9-krab.md
+++ b/src/pages/gene-names/clybl-dcas9-krab.md
@@ -1,0 +1,9 @@
+---
+templateKey: gene-name
+symbol: CLYBL-dCas9-KRAB
+name: citramalyl-CoA lyase safe harbor
+protein: dCas9-KRAB
+structure: nucleolus (nucleus)
+isoforms:
+  - name: CLYBL-dCas9-KRAB
+---

--- a/src/pages/gene-names/ubtf.md
+++ b/src/pages/gene-names/ubtf.md
@@ -1,0 +1,13 @@
+---
+templateKey: gene-name
+symbol: UBTF
+name: upstream binding transcription factor
+protein: nucleolar transcription factor UBF
+structure: nucleolus (fibrillar center)
+isoforms:
+  - name: UBTF
+    ids:
+      - NM_014233
+      - NM_001076684
+      - NM_001076683
+---

--- a/src/templates/cell-line.tsx
+++ b/src/templates/cell-line.tsx
@@ -10,8 +10,8 @@ interface QueryResult {
             frontmatter: {
                 cell_line_id: string;
                 clone_number: number;
-                gene: string;
-                tag_location: string;
+                gene: string[];
+                tag_location: string[];
                 status: string;
                 thumbnail_image: any;
             };
@@ -22,8 +22,8 @@ interface QueryResult {
 interface CellLineProps {
     cellLineId: string;
     cloneNumber: number;
-    gene: string;
-    tagLocation: string;
+    gene: string[];
+    tagLocation: string[];
     status: string;
     thumbnail: any;
 }

--- a/src/templates/disease-cell-line.tsx
+++ b/src/templates/disease-cell-line.tsx
@@ -76,7 +76,7 @@ export const DiseaseCellLineTemplate = ({
                         cellLineId={cellLineId}
                         fluorescentTag={parentalLine.fluorescent_tag}
                         parentalGeneSymbol={
-                            parentalLine.gene.frontmatter.symbol
+                            parentalLine.gene[0].frontmatter.symbol
                         }
                         alleleTag={parentalLine.allele_count}
                         parentalLine={parentalLine}

--- a/src/templates/disease-cell-line.tsx
+++ b/src/templates/disease-cell-line.tsx
@@ -74,7 +74,7 @@ export const DiseaseCellLineTemplate = ({
                 {hasImagesOrVideos && (
                     <ImagesAndVideos
                         cellLineId={cellLineId}
-                        fluorescentTag={parentalLine.fluorescent_tag}
+                        fluorescentTag={[parentalLine.fluorescent_tag[0]]}
                         parentalGeneSymbol={
                             parentalLine.gene[0].frontmatter.symbol
                         }

--- a/src/templates/disease.tsx
+++ b/src/templates/disease.tsx
@@ -1,10 +1,13 @@
 import React from "react";
 import { graphql } from "gatsby";
 import Layout from "../components/Layout";
+import { GeneFrontMatter } from "../component-queries/types";
 
 interface DiseaseTemplateProps {
     name: string;
-    gene: string;
+    gene: {
+        frontmatter: GeneFrontMatter;
+    }[];
 }
 export const DiseaseTemplate = ({ name, gene }: DiseaseTemplateProps) => {
     return (
@@ -13,7 +16,9 @@ export const DiseaseTemplate = ({ name, gene }: DiseaseTemplateProps) => {
                 <div className="columns">
                     <div className="column is-10 is-offset-1">
                         <p>Name: {name}</p>
-                        <p>Gene: {gene}</p>
+                        {gene.map((geneItem, index) => (
+                            <p key={index}>Gene: {geneItem.frontmatter.symbol} - {geneItem.frontmatter.name}</p>
+                        ))}
                     </div>
                 </div>
             </div>
@@ -27,7 +32,7 @@ const Disease = ({ data }: any) => {
         <Layout>
             <DiseaseTemplate
                 name={cellLine.frontmatter.name}
-                gene={`${cellLine.frontmatter.gene.frontmatter.symbol} - ${cellLine.frontmatter.gene.frontmatter.name}`}
+                gene={cellLine.frontmatter.gene}
             />
         </Layout>
     );

--- a/static/admin/config.yml
+++ b/static/admin/config.yml
@@ -75,7 +75,7 @@ collections:
                 label: "Clone Number",
                 name: "clone_number",
                 widget: "number",
-                valueType: int,
+                value_type: int,
                 required: false,
             }
           - {

--- a/static/admin/config.yml
+++ b/static/admin/config.yml
@@ -21,7 +21,7 @@ collections:
       slug: "AICS-{{cell_line_id}}-{{clone_number}}"
       path: "{{slug}}/index"
       identifier_field: "cell_line_id"
-      summary: "AICS-{{cell_line_id}} - {{gene}}"
+      summary: "AICS-{{cell_line_id}} - {{gene[0]}}"
       media_folder: ""
       public_folder: ""
       fields:


### PR DESCRIPTION
Problem
=======
What is the problem this work solves, including
closes #97 

Solution
========
What I/we did to solve this problem
- update query config: return gene as an array instead of an object, tag_location and fluorescent_tag are also arrays
- for disease cell lines and their parental lines, display the first gene's data
- for normal cell lines, show all gene symbols, names, and locations 

## Type of change
Please delete options that are not relevant.

* New feature (non-breaking change which adds functionality)


Steps to Verify:
----------------
1. Check the preview, particularly multi-gene cell lines (AICS-59, 78, 84, 86, 89)

Screenshots (optional):
-----------------------
(TODO: Follow up with UX about multi-tag styling)
<img width="1360" alt="Screenshot 2025-03-31 at 4 40 18 PM" src="https://github.com/user-attachments/assets/47b76d31-9c94-42bf-8b5c-16f4290a55e9" />
