### PR TITLE
fix vial teeth hover state color

### DIFF
--- a/src/style/table.module.css
+++ b/src/style/table.module.css
@@ -61,7 +61,8 @@
     color: var(--WHITE);
 }
 
-.action-column:hover .action-button path {
+.action-column:hover .action-button path,
+.action-column:hover .action-button line {
     fill: var(--primary-color);
     stroke: var(--WHITE);
 }


### PR DESCRIPTION
Problem
=======
_tiny_

Solution / Problem
========
Small design fixes

Teeth on vial should be white when hovered
<img width="162" alt="Screenshot 2025-04-08 at 1 31 26 PM" src="https://github.com/user-attachments/assets/dba2b2da-7e92-4a4a-a62a-0a9b98521450" />
