### PR TITLE
align gene name and tag

### DIFF
--- a/src/components/GeneDisplay.tsx
+++ b/src/components/GeneDisplay.tsx
@@ -8,7 +8,7 @@ interface GeneDisplayProps {
 
 const GeneDisplay: React.FC<GeneDisplayProps> = ({ gene }) => {
     return (
-        <Flex wrap="wrap">
+        <Flex wrap="wrap" align="flex-end">
             <Tag bordered={false} color="#DFE5EA">
                 {gene.symbol}
             </Tag>


### PR DESCRIPTION
Problem
=======
_tiny_

Solution / Problem
========
Small design fixes

Align the gene tag and name in the table. 

<img width="255" alt="Screenshot 2025-04-08 at 1 32 14 PM" src="https://github.com/user-attachments/assets/fc96760b-03c6-438c-91ef-920038f30b95" />
