### PR TITLE
add border radius to coriell button

### DIFF
--- a/src/style/catalog.module.css
+++ b/src/style/catalog.module.css
@@ -28,6 +28,10 @@
     border: 1px solid var(--border-color);
 }
 
+.coriell-card:hover {
+    border: solid 1.5px var(--primary-color);
+}
+
 .coriell-card :global(.ant-card-head) {
     font-family: "Open Sans";
     font-size: 16px;


### PR DESCRIPTION
Problem
=======
_tiny_

Solution / Problem
========
Small design fixes

Need hover state on Coriell button.

<img width="278" alt="Screenshot 2025-04-08 at 1 32 55 PM" src="https://github.com/user-attachments/assets/df8cb7de-faa5-4afd-964a-0160052f6443" />
