### PR TITLE
responsive design font size changes

### DIFF
--- a/src/components/shared/InfoPanel.tsx
+++ b/src/components/shared/InfoPanel.tsx
@@ -18,11 +18,9 @@ const InfoPanel: React.FC<InfoPanelProps> = ({ data }) => {
                 colon={false}
                 labelStyle={{
                     alignItems: "center",
-                    fontSize: "14px",
                 }}
                 contentStyle={{
                     alignItems: "center",
-                    fontSize: "16px",
                     fontWeight: "semi-bold",
                     lineHeight: "1.5",
                 }}

--- a/src/style/cell-line-info-card.module.css
+++ b/src/style/cell-line-info-card.module.css
@@ -54,3 +54,10 @@
         rgba(11, 154, 171, 0.5) 100%
     ) !important;
 }
+
+/* mobile sizing */
+@media (max-width: 744px) {
+    .container .title {
+        font-size: 40px;
+    }
+}

--- a/src/style/clone-table.module.css
+++ b/src/style/clone-table.module.css
@@ -23,3 +23,10 @@
     padding: 5px 16px;
     line-height: 1.4;
 }
+
+/* mobile sizing */
+@media (max-width: 744px) {
+   .container :global(.ant-table-thead .ant-table-cell) {
+        font-size: 12px;
+    }
+}

--- a/src/style/images-and-videos.module.css
+++ b/src/style/images-and-videos.module.css
@@ -41,6 +41,10 @@
     color: var(--SERIOUS_GRAY);
 }
 
+.container .subtitle {
+    font-size: 16px;
+}
+
 .right-title {
     font-size: 12px;
     font-style: italic;
@@ -133,5 +137,12 @@
     .primary-image-with-thumbnail {
         width: 100%;
         flex: 1 1 auto;
+    }
+}
+
+/* mobile sizing */
+@media (max-width: 744px) {
+    .container .subtitle {
+        font-size: 14px;
     }
 }

--- a/src/style/info-panel.module.css
+++ b/src/style/info-panel.module.css
@@ -24,3 +24,21 @@
 .container tbody {
     border-spacing: 10px;
 }
+
+.container :global(.ant-descriptions-item-label) {
+    font-size: 14px;
+}
+
+.container :global(.ant-descriptions-item-content) {
+    font-size: 16px;
+}
+
+/* mobile sizing */
+@media (max-width: 744px) {
+    .container :global(.ant-descriptions-item-label) {
+        font-size: 12px;
+    }
+    .container :global(.ant-descriptions-item-content) {
+        font-size: 14px;
+    }
+}

--- a/src/style/subpage-content-card.module.css
+++ b/src/style/subpage-content-card.module.css
@@ -15,6 +15,7 @@
     /* allows long titles to wrap */
     white-space: normal;
     padding: 16px 0;
+    font-size: 24px;
 }
 
 .container :global(.ant-card-head-wrapper) {
@@ -51,9 +52,12 @@
 }
 
 @media screen and (max-width: 1280px) {
-    .container :global(.ant-card){
+    .container :global(.ant-card) {
         flex-basis: 100%;
         max-width: 100%;
         width: 100%;
+    }
+    .container :global(.ant-card-head-title) {
+        font-size: 16px;
     }
 }


### PR DESCRIPTION
Problem
=======
Closes #117 

Solution
========
Apply a set of font reduction rules for tablet and mobile designs.

Fairly simple application of media queries and one case where I removed prop based styling that was hard to target. In general as styling gets more complex/responsive I prioritize stylesheet over inline or prop based styles.

* New feature (non-breaking change which adds functionality)

Screenshots (optional):
-----------------------
Full size:
<img width="817" alt="Screenshot 2025-05-07 at 11 25 08 AM" src="https://github.com/user-attachments/assets/570d757b-59be-4749-9c8b-c18c590f7d49" />
Below 744px:
<img width="584" alt="Screenshot 2025-05-07 at 11 26 13 AM" src="https://github.com/user-attachments/assets/4c07ac35-206f-4134-a086-233faf2d42c3" />
Fullsize:
<img width="1152" alt="Screenshot 2025-05-07 at 11 25 45 AM" src="https://github.com/user-attachments/assets/2495760c-72d5-4b29-8ef4-2e133adae900" />
Below 1280px:
<img width="894" alt="Screenshot 2025-05-07 at 11 25 52 AM" src="https://github.com/user-attachments/assets/dbfefce9-322e-4850-9bd8-8519e97e6631" />

