### PR TITLE
Admin page: cell line preview 

### DIFF
--- a/src/cms/preview-templates/CellLinePreview.tsx
+++ b/src/cms/preview-templates/CellLinePreview.tsx
@@ -22,7 +22,6 @@ const CellLinePreview = ({ entry, getAsset }: TemplateProps) => {
     const fluorescentTags = geneticModifications.map((mod: any) => mod.fluorescent_tag).join(" / ");
     const alleleCounts = geneticModifications.map((mod: any) => mod.allele_count).join(" / ");
 
-    // TODO: should add protein, structure and name? what's the best way?
     const data = [
         {
             key: "cell_line_id",

--- a/src/cms/preview-templates/CellLinePreview.tsx
+++ b/src/cms/preview-templates/CellLinePreview.tsx
@@ -1,22 +1,74 @@
 import React from "react";
-import { CellLineTemplate } from "../../templates/cell-line";
 import { TemplateProps } from "./types";
 import useDisableWheel from "../hooks/useDisableWheel";
+import InfoPanel from "../../components/shared/InfoPanel";
+import ProgressPreview from "./ProgressPreview";
+import { GatsbyImage, getImage } from "gatsby-plugin-image";
+
 
 const CellLinePreview = ({ entry }: TemplateProps) => {
+    useDisableWheel();
     const geneticModificationsEntry = entry.getIn(["data", "genetic_modifications"]);
     const geneticModifications = geneticModificationsEntry ?
         geneticModificationsEntry.toJS() : 
         [];
-    useDisableWheel();
+
+    // TODO: debug gastby-image
+    const thumbnail = entry.getIn(["data", "thumbnail_image"]);
+    const thumbnailImage = getImage(thumbnail);
+
+    const status = entry.getIn(["data", "status"]);
+    const genes = geneticModifications.map((mod: any) => mod.gene).join(" / ");
+    const tagLocations = geneticModifications.map((mod: any) => mod.tag_location).join(" / ");
+    const fluorescentTags = geneticModifications.map((mod: any) => mod.fluorescent_tag).join(" / ");
+    const alleleCounts = geneticModifications.map((mod: any) => mod.allele_count).join(" / ");
+
+    // TODO: should add protein, structure and name? what's the best way?
+    const data = [
+        {
+            key: "cell_line_id",
+            label: "Cell Line ID",
+            children: entry.getIn(["data", "cell_line_id"]),
+        },
+        {
+            key: "clone_number",
+            label: "Clone Number",
+            children: entry.getIn(["data", "clone_number"]),
+        },
+        {
+            key: "gene",
+            label: "Gene",
+            children: genes,
+        },
+        {
+            key: "tag_location",
+            label: "Tag Location",
+            children: tagLocations,
+        },
+        {
+            key: "fluorescent_tag",
+            label: "Fluorescent Tag",
+            children: fluorescentTags,
+        },
+        {
+            key: "allele_count",
+            label: "Allele Count",
+            children: alleleCounts,
+        },
+    ];
+
+    // TODO: does this current info panel component fit in here?
     return (
-        <CellLineTemplate
-            cellLineId={entry.getIn(["data", "cell_line_id"])}
-            cloneNumber={entry.getIn(["data", "clone_number"])}
-            geneticModifications={geneticModifications}
-            status={entry.getIn(["data", "status"])}
-            thumbnail={entry.getIn(["data", "thumbnail_image"])}
-        />
+        <>
+            <ProgressPreview status={status} />
+            <InfoPanel data={data} />
+            {thumbnailImage && (
+                <GatsbyImage
+                    image={thumbnailImage}
+                    alt="Cell Line Thumbnail"
+                />
+            )}
+        </>
     );
 };
 

--- a/src/cms/preview-templates/CellLinePreview.tsx
+++ b/src/cms/preview-templates/CellLinePreview.tsx
@@ -3,19 +3,18 @@ import { TemplateProps } from "./types";
 import useDisableWheel from "../hooks/useDisableWheel";
 import InfoPanel from "../../components/shared/InfoPanel";
 import ProgressPreview from "./ProgressPreview";
-import { GatsbyImage, getImage } from "gatsby-plugin-image";
+import PreviewCompatibleImage from "../../components/PreviewCompatibleImage";
 
 
-const CellLinePreview = ({ entry }: TemplateProps) => {
+const CellLinePreview = ({ entry, getAsset }: TemplateProps) => {
     useDisableWheel();
     const geneticModificationsEntry = entry.getIn(["data", "genetic_modifications"]);
     const geneticModifications = geneticModificationsEntry ?
         geneticModificationsEntry.toJS() : 
         [];
 
-    // TODO: debug gastby-image
     const thumbnail = entry.getIn(["data", "thumbnail_image"]);
-    const thumbnailImage = getImage(thumbnail);
+    const thumbnailImage = getAsset(thumbnail);
 
     const status = entry.getIn(["data", "status"]);
     const genes = geneticModifications.map((mod: any) => mod.gene).join(" / ");
@@ -55,19 +54,27 @@ const CellLinePreview = ({ entry }: TemplateProps) => {
             label: "Allele Count",
             children: alleleCounts,
         },
+        ...(thumbnailImage ? [{
+            key: "thumbnail",
+            label: "Thumbnail Image",
+            children: (
+                <PreviewCompatibleImage
+                    imageInfo={{
+                        image: thumbnailImage.url,
+                        alt: "Cell Line Thumbnail"
+                    }}
+                    imageStyle={{ 
+                        maxWidth: "400px",
+                    }}
+                />
+            ),
+        }] : []),
     ];
 
-    // TODO: does this current info panel component fit in here?
     return (
         <>
-            <ProgressPreview status={status} />
+            <ProgressPreview collection={"cell_lines"} status={status} />
             <InfoPanel data={data} />
-            {thumbnailImage && (
-                <GatsbyImage
-                    image={thumbnailImage}
-                    alt="Cell Line Thumbnail"
-                />
-            )}
         </>
     );
 };

--- a/src/cms/preview-templates/DiseaseCellLinePreview.tsx
+++ b/src/cms/preview-templates/DiseaseCellLinePreview.tsx
@@ -78,7 +78,7 @@ const DiseaseCellLinePreview = ({ entry, getAsset }: TemplateProps) => {
     }
     return (
         <>
-            <ProgressPreview status={status} />
+            <ProgressPreview collection={"disease"} status={status} />
             <InfoPanel data={data} />
             <CloneTable dataSource={cloneData} />
 

--- a/src/cms/preview-templates/ProgressPreview.tsx
+++ b/src/cms/preview-templates/ProgressPreview.tsx
@@ -1,16 +1,69 @@
 import React from "react";
-import { Steps } from "antd";
+import { Descriptions, Steps } from "antd";
 import { CellLineStatus } from "../../component-queries/types";
 
 interface ProgressPreviewProps {
+    collection: string;
     status: CellLineStatus;
 }
-const ProgressPreview = ({ status }: ProgressPreviewProps) => {
-    const statusMap = {
+const ProgressPreview = ({ collection, status }: ProgressPreviewProps) => {
+    const diseaseStatusMap = {
         [CellLineStatus.DataComplete]: 2,
         [CellLineStatus.Released]: 1,
         [CellLineStatus.InProgress]: 0,
     };
+    const cellLineStatusMap = {
+        [CellLineStatus.DataComplete]: 3,
+        [CellLineStatus.Released]: 2,
+        [CellLineStatus.InProgress]: 1,
+        [CellLineStatus.Hide]: 0,
+    };
+
+    const diseaseLineStatus = [
+        {
+            title: "Initiated",
+        },
+        {
+            title: "Released",
+            description: "Visible on main table",
+        },
+        {
+            title: "QC data finished",
+            description: "Subpages are complete",
+        },
+    ];
+    const cellLineStatus = [
+        {
+            title: "Initiated",
+        },
+        {
+            title: "In Progress",
+            description: "Visible but not clickable on the 'in progress' table",
+        },
+        {
+            title: "Released",
+            description: "Visible and clickable on main table",
+        },
+        {
+            title: "QC data finished",
+            description: "Subpages are complete",
+        },
+    ];
+    const hideStatus = [
+        {
+            title: "Hide",
+            description: "Entered data is saved and the line is hidden",
+        }
+    ];
+
+    let statusList = collection === "disease" ? diseaseLineStatus : cellLineStatus;
+    const statusMap = collection === "disease" ? diseaseStatusMap : cellLineStatusMap;
+    let currentStatus = 0;
+    if (status === CellLineStatus.Hide) {
+        statusList = hideStatus;
+    } else {
+        currentStatus = statusMap[status];
+    }
     return (
         <Steps
             style={{
@@ -18,20 +71,11 @@ const ProgressPreview = ({ status }: ProgressPreviewProps) => {
                 backgroundColor: "#f0f0f0",
             }}
             size="small"
-            current={statusMap[status]}
-            items={[
-                {
-                    title: "Initiated",
-                },
-                {
-                    title: "Released",
-                    description: "Visible on main table",
-                },
-                {
-                    title: "QC data finished",
-                    description: "Subpages are complete",
-                },
-            ]}
+            current={currentStatus}
+            items={statusList.map((item) => ({
+                title: item.title,
+                description: item.description,
+            }))}
         />
     );
 };

--- a/src/component-queries/types.ts
+++ b/src/component-queries/types.ts
@@ -55,6 +55,7 @@ export enum CellLineStatus {
     DataComplete = "data complete",
     Released = "released",
     InProgress = "in progress",
+    Hide = "hide",
 }
 
 enum Antibody {


### PR DESCRIPTION
Problem
=======
What is the problem this work solves, including
closes #135 

Solution
========
What I/we did to solve this problem
- added preview data for normal cell lines in admin page

## Type of change
Please delete options that are not relevant.

* New feature (non-breaking change which adds functionality)


Steps to Verify:
----------------
1. admin page preview

Screenshots (optional):
-----------------------

<img width="800" alt="Screenshot 2025-05-21 at 2 10 50 PM" src="https://github.com/user-attachments/assets/cadff9d5-fe1f-40bf-ae69-d8419eb39ca9" />

