### PR TITLE
Feature/col width

### DIFF
--- a/src/components/CellLineTable/NormalTableColumns.tsx
+++ b/src/components/CellLineTable/NormalTableColumns.tsx
@@ -18,6 +18,9 @@ const {
     actionColumn,
     actionButton,
     plasmidIcon,
+    protein,
+    gene,
+    structure,
 } = require("../../style/table.module.css");
 
 const caseInsensitiveStringCompare = (a = "", b = "") =>
@@ -83,6 +86,7 @@ export const getNormalTableColumns = (
             width: 200,
             responsive: mdBreakpoint,
             sortIcon: sortIcon,
+            className: protein,
             sorter: (a: any, b: any) =>
                 caseInsensitiveStringCompare(a.protein, b.protein),
         },
@@ -92,6 +96,8 @@ export const getNormalTableColumns = (
             key: "taggedGene",
             dataIndex: "taggedGene",
             responsive: mdBreakpoint,
+            sortIcon: sortIcon,
+            className: gene,
             render: (taggedGene: UnpackedGene[]) => {
                 return (
                     <>
@@ -101,7 +107,6 @@ export const getNormalTableColumns = (
                     </>
                 );
             },
-            sortIcon: sortIcon,
             sorter: (a: any, b: any) =>
                 caseInsensitiveStringCompare(
                     a.taggedGene[0].name,
@@ -124,7 +129,7 @@ export const getNormalTableColumns = (
             dataIndex: "structure",
             responsive: mdBreakpoint,
             sortIcon: sortIcon,
-
+            className: structure,
             sorter: (a: any, b: any) =>
                 caseInsensitiveStringCompare(a.structure, b.structure),
         },

--- a/src/components/CellLineTable/NormalTableColumns.tsx
+++ b/src/components/CellLineTable/NormalTableColumns.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Flex } from "antd";
+import { Flex, Typography, TooltipProps } from "antd";
 import Icon, { CaretDownOutlined, CaretUpOutlined } from "@ant-design/icons";
 import { SortOrder } from "antd/es/table/interface";
 import {
@@ -12,6 +12,7 @@ import { cellLineIdColumn, obtainLineColumn } from "./SharedColumns";
 import { CellLineColumns, mdBreakpoint } from "./types";
 
 const Plasmid = require("../../img/plasmid.svg");
+const { Text } = Typography;
 
 const {
     lastColumn,
@@ -21,6 +22,8 @@ const {
     protein,
     gene,
     structure,
+    tooltip,
+    truncatedText,
 } = require("../../style/table.module.css");
 
 const caseInsensitiveStringCompare = (a = "", b = "") =>
@@ -37,6 +40,10 @@ const sortIcon = ({ sortOrder }: { sortOrder: SortOrder }) => {
     ) : (
         <CaretUpOutlined style={{ color: SERIOUS_GRAY, fontSize: 16 }} />
     );
+};
+
+const tooltipProps = (text: string): TooltipProps => {
+    return { title: text, arrow: false, rootClassName: tooltip };
 };
 
 const obtainPlasmidColumn = {
@@ -83,16 +90,25 @@ export const getNormalTableColumns = (
             title: "Protein",
             key: "protein",
             dataIndex: "protein",
-            width: 200,
+            width: 220,
             responsive: mdBreakpoint,
             sortIcon: sortIcon,
             className: protein,
+            render: (text: string) => (
+                <Text
+                    className={truncatedText}
+                    ellipsis={{ tooltip: tooltipProps(text) }}
+                >
+                    {text}
+                </Text>
+            ),
+
             sorter: (a: any, b: any) =>
                 caseInsensitiveStringCompare(a.protein, b.protein),
         },
         {
             title: "Gene Symbol & Name",
-            width: 280,
+            width: 310,
             key: "taggedGene",
             dataIndex: "taggedGene",
             responsive: mdBreakpoint,
@@ -125,11 +141,19 @@ export const getNormalTableColumns = (
         {
             title: "Structure",
             key: "structure",
-            width: 280,
+            width: 220,
             dataIndex: "structure",
             responsive: mdBreakpoint,
             sortIcon: sortIcon,
             className: structure,
+            render: (text: string) => (
+                <Text
+                    className={truncatedText}
+                    ellipsis={{ tooltip: tooltipProps(text) }}
+                >
+                    {text}
+                </Text>
+            ),
             sorter: (a: any, b: any) =>
                 caseInsensitiveStringCompare(a.structure, b.structure),
         },

--- a/src/components/GeneDisplay.tsx
+++ b/src/components/GeneDisplay.tsx
@@ -1,14 +1,12 @@
 import React from "react";
-import { Flex, Tag } from "antd";
+import { Flex, Tag, Typography } from "antd";
 import { UnpackedGene } from "../component-queries/types";
-
 interface GeneDisplayProps {
     gene: UnpackedGene;
 }
 
-const {
-    geneName,
-} = require("../style/table.module.css");
+const { truncatedText, tooltip } = require("../style/table.module.css");
+const { Text } = Typography;
 
 const GeneDisplay: React.FC<GeneDisplayProps> = ({ gene }) => {
     return (
@@ -16,7 +14,18 @@ const GeneDisplay: React.FC<GeneDisplayProps> = ({ gene }) => {
             <Tag bordered={false} color="#DFE5EA">
                 {gene.symbol}
             </Tag>
-            <div className={geneName}>{gene.name}</div>
+            <Text
+                className={truncatedText}
+                ellipsis={{
+                    tooltip: {
+                        title: gene.name,
+                        arrow: false,
+                        rootClassName: tooltip,
+                    },
+                }}
+            >
+                {gene.name}
+            </Text>
         </Flex>
     );
 };

--- a/src/components/GeneDisplay.tsx
+++ b/src/components/GeneDisplay.tsx
@@ -6,13 +6,17 @@ interface GeneDisplayProps {
     gene: UnpackedGene;
 }
 
+const {
+    geneName,
+} = require("../style/table.module.css");
+
 const GeneDisplay: React.FC<GeneDisplayProps> = ({ gene }) => {
     return (
-        <Flex wrap="wrap" align="flex-end">
+        <Flex wrap="nowrap" align="flex-end">
             <Tag bordered={false} color="#DFE5EA">
                 {gene.symbol}
             </Tag>
-            <div>{gene.name}</div>
+            <div className={geneName}>{gene.name}</div>
         </Flex>
     );
 };

--- a/src/style/colors.sass
+++ b/src/style/colors.sass
@@ -7,6 +7,7 @@
     --SERIOUS_GRAY: #323233;
     --AQUA_BLUE: #0B9AAB;
     --RED: #FF0000;
+    --GRAY_60: #323233;
 
     --ALLEN_LIGHT_10: #DFE5EA;
     --ALLEN_LIGHT_30: #9FB1C0;
@@ -19,5 +20,6 @@
     --link-color: #0094FF;
     --small-table-border-color: var(--RAIN_SHADOW);
     --main-card-header-color: var(--primary-color);
+    --tooltip-background: var(--GRAY_60);
 }
 

--- a/src/style/table.module.css
+++ b/src/style/table.module.css
@@ -184,20 +184,27 @@
 .container .protein,
 .container .structure {
     max-width: 220px;
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
 }
 
 .container .gene {
     max-width: 310px;
-    flex-wrap: nowrap;
 }
 
-.container .gene-name {
+.container .truncated-text {
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
+}
+
+.tooltip:global(.ant-tooltip) {
+    max-width: none;
+}
+
+.tooltip :global(.ant-tooltip-inner) {
+    background-color: var(--tooltip-background);
+    border-radius: 0;
+    min-height: 0;
+    padding: 2px;
 }
 
 .container :global(.ant-table-column-sorters) {

--- a/src/style/table.module.css
+++ b/src/style/table.module.css
@@ -68,7 +68,7 @@
 }
 
 .action-column:hover .plasmid-icon path {
-  fill: var(--WHITE);
+    fill: var(--WHITE);
 }
 
 .container h4 {
@@ -179,6 +179,25 @@
     font-weight: 600;
     font-weight: 300;
     color: var(--ALLEN_LIGHT_60);
+}
+
+.container .protein,
+.container .structure {
+    max-width: 220px;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.container .gene {
+    max-width: 310px;
+    flex-wrap: nowrap;
+}
+
+.container .gene-name {
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
 }
 
 .container :global(.ant-table-column-sorters) {


### PR DESCRIPTION
Problem
=======
Closes #173 
Advances #140

Solution
========

Apply max width to relevant columns: gene, protein, structure.
Truncate text below max width with CSS.
Configure tooltip on truncated text with antd `Text` component and `ellipsis` prop config.
Style tooltip. [desgin](https://www.figma.com/design/kMIJN6BoOkXIhnVUruIHNT/Website-allencell.org?node-id=4975-8714&t=PB2MobCYAt1b1FFU-4)

Padding on the side of tooltip looks a little tight to me, will ask Travis but it matches design right now (2px).

![Screenshot 2025-05-21 at 6 02 26 PM](https://github.com/user-attachments/assets/a6c637e4-f5f5-47c5-aa45-65e42ec4901b)
