### PR TITLE
render thumbnails for cell line main table

### DIFF
--- a/src/component-queries/NormalCellLines.tsx
+++ b/src/component-queries/NormalCellLines.tsx
@@ -94,7 +94,6 @@ export default function NormalCellLines() {
                                         childImageSharp {
                                             gatsbyImageData(
                                                 placeholder: BLURRED
-                                                layout: FIXED
                                             )
                                         }
                                     }

--- a/src/component-queries/NormalCellLines.tsx
+++ b/src/component-queries/NormalCellLines.tsx
@@ -90,6 +90,14 @@ export default function NormalCellLines() {
                                     status
                                     order_link
                                     donor_plasmid
+                                    thumbnail_image {
+                                        childImageSharp {
+                                            gatsbyImageData(
+                                                placeholder: BLURRED
+                                                layout: FIXED
+                                            )
+                                        }
+                                    }
                                     genetic_modifications {
                                         gene {
                                             frontmatter {

--- a/src/component-queries/NormalCellLines.tsx
+++ b/src/component-queries/NormalCellLines.tsx
@@ -94,6 +94,7 @@ export default function NormalCellLines() {
                                         childImageSharp {
                                             gatsbyImageData(
                                                 placeholder: BLURRED
+                                                width: 164
                                             )
                                         }
                                     }

--- a/src/component-queries/convert-data.ts
+++ b/src/component-queries/convert-data.ts
@@ -93,5 +93,6 @@ export const convertFrontmatterToNormalCellLines = ({
         healthCertificate: "",
         orderLink: cellLineNode.frontmatter.order_link,
         orderPlasmid: cellLineNode.frontmatter.donor_plasmid,
+        thumbnailImage: cellLineNode.frontmatter.thumbnail_image,
     };
 };

--- a/src/component-queries/types.ts
+++ b/src/component-queries/types.ts
@@ -37,6 +37,7 @@ export interface NormalCellLineFrontmatter {
     order_link: string;
     genetic_modifications?: GeneticModification[];
     donor_plasmid: string;
+    thumbnail_image: FileNode;
     parental_line: {
         frontmatter: {
             name: string;
@@ -186,6 +187,7 @@ export interface UnpackedNormalCellLine extends UnpackedCellLineMainInfo {
         fluorescentTag: string;
     }[];
     orderPlasmid: string;
+    thumbnailImage: FileNode;
 }
 
 export type ParentLine = Partial<UnpackedNormalCellLine>;

--- a/src/components/CellLineTable/DiseaseTableColumns.tsx
+++ b/src/components/CellLineTable/DiseaseTableColumns.tsx
@@ -1,12 +1,14 @@
 import React from "react";
 import { Flex } from "antd";
 import classNames from "classnames";
+import { Link } from "gatsby";
 
 import {
     Clone,
     UnpackedDiseaseCellLine,
     UnpackedGene,
     UnpackedNormalCellLine,
+    CellLineStatus,
 } from "../../component-queries/types";
 import { formatCellLineId, getCloneSummary } from "../../utils";
 import GeneDisplay from "../GeneDisplay";
@@ -14,17 +16,38 @@ import ParentalLineModal from "../ParentalLineModal";
 import CloneSummary from "../CloneSummary";
 
 import {
-    cellLineIdColumn,
     certificateOfAnalysisColumn,
     obtainLineColumn,
 } from "./SharedColumns";
-import { smBreakPoint, mdBreakpoint, CellLineColumns } from "./types";
+import { smBreakPoint, mdBreakpoint, CellLineColumns, UnpackedCellLine } from "./types";
 
 const {
     clones,
     lastColumn,
     snpColumn,
+    cellLineId,
 } = require("../../style/table.module.css");
+
+const cellLineIdColumn = {
+    title: "Cell Collection ID",
+    key: "cellLineId",
+    className: cellLineId,
+    dataIndex: "cellLineId",
+    fixed: "left" as const,
+    width: 164,
+    render: (cellLineId: number, record: UnpackedCellLine) => {
+        const cellLine = (
+            <h4 key={cellLineId}>{formatCellLineId(cellLineId)}</h4>
+        );
+        return record.status === CellLineStatus.DataComplete ? (
+            <Link to={record.path}>
+                {cellLine}
+            </Link>
+        ) : (
+            cellLine
+        );
+    },
+};
 
 export const getDiseaseTableColumns = (
     inProgress: boolean

--- a/src/components/CellLineTable/DiseaseTableColumns.tsx
+++ b/src/components/CellLineTable/DiseaseTableColumns.tsx
@@ -34,7 +34,6 @@ const cellLineIdColumn = {
     className: cellLineId,
     dataIndex: "cellLineId",
     fixed: "left" as const,
-    width: 164,
     render: (cellLineId: number, record: UnpackedCellLine) => {
         const cellLine = (
             <h4 key={cellLineId}>{formatCellLineId(cellLineId)}</h4>

--- a/src/components/CellLineTable/NormalTableColumns.tsx
+++ b/src/components/CellLineTable/NormalTableColumns.tsx
@@ -5,11 +5,15 @@ import { SortOrder } from "antd/es/table/interface";
 import {
     UnpackedGene,
     UnpackedNormalCellLine,
+    CellLineStatus,
 } from "../../component-queries/types";
 import { RAIN_SHADOW, SERIOUS_GRAY } from "../../style/theme";
 import GeneDisplay from "../GeneDisplay";
-import { cellLineIdColumn, obtainLineColumn } from "./SharedColumns";
-import { CellLineColumns, mdBreakpoint } from "./types";
+import { obtainLineColumn } from "./SharedColumns";
+import { CellLineColumns, mdBreakpoint, UnpackedCellLine } from "./types";
+import { formatCellLineId } from "../../utils";
+import { GatsbyImage, getImage } from "gatsby-plugin-image";
+import { Link } from "gatsby";
 
 const Plasmid = require("../../img/plasmid.svg");
 
@@ -18,6 +22,10 @@ const {
     actionColumn,
     actionButton,
     plasmidIcon,
+    cellLineId,
+    thumbnailContainer,
+    idColumn,
+    idHeader,
 } = require("../../style/table.module.css");
 
 const caseInsensitiveStringCompare = (a = "", b = "") =>
@@ -34,6 +42,46 @@ const sortIcon = ({ sortOrder }: { sortOrder: SortOrder }) => {
     ) : (
         <CaretUpOutlined style={{ color: SERIOUS_GRAY, fontSize: 16 }} />
     );
+};
+
+const cellLineIdColumn = {
+    title: "Cell Collection ID",
+    key: "cellLineId",
+    className: cellLineId,
+    dataIndex: "cellLineId",
+    fixed: "left" as const,
+    render: (cellLineId: number, record: UnpackedCellLine) => {
+        const formattedId = formatCellLineId(cellLineId);
+        const cellLine = (
+            <h4 key={cellLineId}>{formattedId}</h4>
+        );
+        const thumbnailImage = record.thumbnailImage?.childImageSharp?.gatsbyImageData ?
+            getImage(record.thumbnailImage.childImageSharp.gatsbyImageData) : null;
+        const content = (
+            <div className={idColumn}>
+                <div className={idHeader}>
+                    {cellLine}
+                </div>
+                {thumbnailImage && (
+                    <div className={thumbnailContainer}>
+                        <GatsbyImage
+                            image={thumbnailImage}
+                            alt={`${formattedId} thumbnail`}
+                            style={{ width: "100%", height: "100%" }}
+                            objectFit="cover"
+                        />
+                    </div>
+                )}
+            </div>
+        );
+        return record.status === CellLineStatus.DataComplete ? (
+            <Link to={record.path}>
+                {content}
+            </Link>
+        ) : (
+            content
+        );
+    },
 };
 
 const obtainPlasmidColumn = {

--- a/src/components/CellLineTable/NormalTableColumns.tsx
+++ b/src/components/CellLineTable/NormalTableColumns.tsx
@@ -1,4 +1,6 @@
 import React from "react";
+import { GatsbyImage, getImage } from "gatsby-plugin-image";
+import { Link } from "gatsby";
 import { Flex } from "antd";
 import Icon, { CaretDownOutlined, CaretUpOutlined } from "@ant-design/icons";
 import { SortOrder } from "antd/es/table/interface";
@@ -12,8 +14,6 @@ import GeneDisplay from "../GeneDisplay";
 import { obtainLineColumn } from "./SharedColumns";
 import { CellLineColumns, mdBreakpoint, UnpackedCellLine } from "./types";
 import { formatCellLineId } from "../../utils";
-import { GatsbyImage, getImage } from "gatsby-plugin-image";
-import { Link } from "gatsby";
 
 const Plasmid = require("../../img/plasmid.svg");
 
@@ -24,7 +24,6 @@ const {
     plasmidIcon,
     cellLineId,
     thumbnailContainer,
-    idColumn,
     idHeader,
 } = require("../../style/table.module.css");
 
@@ -58,21 +57,17 @@ const cellLineIdColumn = {
         const thumbnailImage = record.thumbnailImage?.childImageSharp?.gatsbyImageData ?
             getImage(record.thumbnailImage.childImageSharp.gatsbyImageData) : null;
         const content = (
-            <div className={idColumn}>
-                <div className={idHeader}>
-                    {cellLine}
-                </div>
+            <>
+                <div className={idHeader}>{cellLine}</div>
                 {thumbnailImage && (
                     <div className={thumbnailContainer}>
                         <GatsbyImage
                             image={thumbnailImage}
                             alt={`${formattedId} thumbnail`}
-                            style={{ width: "100%", height: "100%" }}
-                            objectFit="cover"
                         />
                     </div>
                 )}
-            </div>
+            </>
         );
         return record.status === CellLineStatus.DataComplete ? (
             <Link to={record.path}>

--- a/src/components/CellLineTable/NormalTableColumns.tsx
+++ b/src/components/CellLineTable/NormalTableColumns.tsx
@@ -49,7 +49,6 @@ const cellLineIdColumn = {
     className: cellLineId,
     dataIndex: "cellLineId",
     fixed: "left" as const,
-    width: 164,
     render: (cellLineId: number, record: UnpackedCellLine) => {
         const formattedId = formatCellLineId(cellLineId);
         const cellLine = (

--- a/src/components/CellLineTable/NormalTableColumns.tsx
+++ b/src/components/CellLineTable/NormalTableColumns.tsx
@@ -49,6 +49,7 @@ const cellLineIdColumn = {
     className: cellLineId,
     dataIndex: "cellLineId",
     fixed: "left" as const,
+    width: 164,
     render: (cellLineId: number, record: UnpackedCellLine) => {
         const formattedId = formatCellLineId(cellLineId);
         const cellLine = (

--- a/src/components/CellLineTable/SharedColumns.tsx
+++ b/src/components/CellLineTable/SharedColumns.tsx
@@ -1,7 +1,8 @@
 import { Link } from "gatsby";
 import React from "react";
-import { Flex } from "antd";
+import { Flex, Space } from "antd";
 import Icon from "@ant-design/icons";
+import { GatsbyImage, getImage } from "gatsby-plugin-image";
 
 import { CellLineStatus } from "../../component-queries/types";
 import { formatCellLineId } from "../../utils";
@@ -16,6 +17,7 @@ const {
     actionColumn,
     actionButton,
     tubeIcon,
+    thumbnailContainer,
 } = require("../../style/table.module.css");
 
 export const cellLineIdColumn = {
@@ -25,13 +27,29 @@ export const cellLineIdColumn = {
     dataIndex: "cellLineId",
     fixed: "left" as const,
     render: (cellLineId: number, record: UnpackedCellLine) => {
+        const formattedId = formatCellLineId(cellLineId);
         const cellLine = (
-            <h4 key={cellLineId}>{formatCellLineId(cellLineId)}</h4>
+            <h4 key={cellLineId}>{formattedId}</h4>
+        );
+        const thumbnailImage = record.thumbnailImage?.childImageSharp?.gatsbyImageData ?
+            getImage(record.thumbnailImage.childImageSharp.gatsbyImageData) : null;
+        const content = (
+            <Space>
+                {thumbnailImage && (
+                    <div className={thumbnailContainer}>
+                        <GatsbyImage
+                            image={thumbnailImage}
+                            alt={`${formattedId} thumbnail`}
+                        />
+                    </div>
+                )}
+                {cellLine}
+            </Space>
         );
         return record.status === CellLineStatus.DataComplete ? (
             <Link to={record.path}>{cellLine}</Link>
         ) : (
-            cellLine
+            content
         );
     },
 };

--- a/src/components/CellLineTable/SharedColumns.tsx
+++ b/src/components/CellLineTable/SharedColumns.tsx
@@ -18,26 +18,8 @@ const {
     tubeIcon,
 } = require("../../style/table.module.css");
 
-// TODO: move to DiseaseTableColumns?
-export const cellLineIdColumn = {
-    title: "Cell Collection ID",
-    key: "cellLineId",
-    className: cellLineId,
-    dataIndex: "cellLineId",
-    fixed: "left" as const,
-    render: (cellLineId: number, record: UnpackedCellLine) => {
-        const cellLine = (
-            <h4 key={cellLineId}>{formatCellLineId(cellLineId)}</h4>
-        );
-        return record.status === CellLineStatus.DataComplete ? (
-            <Link to={record.path}>
-                {cellLine}
-            </Link>
-        ) : (
-            cellLine
-        );
-    },
-};
+
+
 
 export const certificateOfAnalysisColumn = {
     title: "",

--- a/src/components/CellLineTable/SharedColumns.tsx
+++ b/src/components/CellLineTable/SharedColumns.tsx
@@ -1,6 +1,6 @@
 import { Link } from "gatsby";
 import React from "react";
-import { Flex, Space } from "antd";
+import { Flex } from "antd";
 import Icon from "@ant-design/icons";
 import { GatsbyImage, getImage } from "gatsby-plugin-image";
 
@@ -18,6 +18,8 @@ const {
     actionButton,
     tubeIcon,
     thumbnailContainer,
+    idColumn,
+    idHeader,
 } = require("../../style/table.module.css");
 
 export const cellLineIdColumn = {
@@ -34,20 +36,26 @@ export const cellLineIdColumn = {
         const thumbnailImage = record.thumbnailImage?.childImageSharp?.gatsbyImageData ?
             getImage(record.thumbnailImage.childImageSharp.gatsbyImageData) : null;
         const content = (
-            <Space>
+            <div className={idColumn}>
+                <div className={idHeader}>
+                    {cellLine}
+                </div>
                 {thumbnailImage && (
                     <div className={thumbnailContainer}>
                         <GatsbyImage
                             image={thumbnailImage}
                             alt={`${formattedId} thumbnail`}
+                            style={{ width: "100%", height: "100%" }}
+                            objectFit="cover"
                         />
                     </div>
                 )}
-                {cellLine}
-            </Space>
+            </div>
         );
         return record.status === CellLineStatus.DataComplete ? (
-            <Link to={record.path}>{cellLine}</Link>
+            <Link to={record.path}>
+                {content}
+            </Link>
         ) : (
             content
         );

--- a/src/components/CellLineTable/SharedColumns.tsx
+++ b/src/components/CellLineTable/SharedColumns.tsx
@@ -2,7 +2,6 @@ import { Link } from "gatsby";
 import React from "react";
 import { Flex } from "antd";
 import Icon from "@ant-design/icons";
-import { GatsbyImage, getImage } from "gatsby-plugin-image";
 
 import { CellLineStatus } from "../../component-queries/types";
 import { formatCellLineId } from "../../utils";
@@ -17,11 +16,9 @@ const {
     actionColumn,
     actionButton,
     tubeIcon,
-    thumbnailContainer,
-    idColumn,
-    idHeader,
 } = require("../../style/table.module.css");
 
+// TODO: move to DiseaseTableColumns?
 export const cellLineIdColumn = {
     title: "Cell Collection ID",
     key: "cellLineId",
@@ -29,35 +26,15 @@ export const cellLineIdColumn = {
     dataIndex: "cellLineId",
     fixed: "left" as const,
     render: (cellLineId: number, record: UnpackedCellLine) => {
-        const formattedId = formatCellLineId(cellLineId);
         const cellLine = (
-            <h4 key={cellLineId}>{formattedId}</h4>
-        );
-        const thumbnailImage = record.thumbnailImage?.childImageSharp?.gatsbyImageData ?
-            getImage(record.thumbnailImage.childImageSharp.gatsbyImageData) : null;
-        const content = (
-            <div className={idColumn}>
-                <div className={idHeader}>
-                    {cellLine}
-                </div>
-                {thumbnailImage && (
-                    <div className={thumbnailContainer}>
-                        <GatsbyImage
-                            image={thumbnailImage}
-                            alt={`${formattedId} thumbnail`}
-                            style={{ width: "100%", height: "100%" }}
-                            objectFit="cover"
-                        />
-                    </div>
-                )}
-            </div>
+            <h4 key={cellLineId}>{formatCellLineId(cellLineId)}</h4>
         );
         return record.status === CellLineStatus.DataComplete ? (
             <Link to={record.path}>
-                {content}
+                {cellLine}
             </Link>
         ) : (
-            content
+            cellLine
         );
     },
 };

--- a/src/style/table.module.css
+++ b/src/style/table.module.css
@@ -15,13 +15,6 @@
     position: absolute; 
 }
 
-.id-column {
-    position: relative;
-    width: 100%; 
-    height: 100%; 
-    min-height: 80px;
-}
-
 .id-header {
     position: absolute;
     top: 0; 
@@ -31,6 +24,10 @@
     background-color: var(--WHITE);
     opacity: 0.85;
     text-align: center; 
+}
+
+.container .id-header h4 {
+    margin: 0px;
 }
 
 .container :global(.ant-table-container) {
@@ -104,9 +101,12 @@
     padding: 14px 16px;
 }
 
-.container :global(.ant-table-thead .ant-table-cell).cell-line-id,
-.container :global(.ant-table-cell).cell-line-id {
+.container :global(.ant-table-thead .ant-table-cell).cell-line-id {
     padding: 10px 16px 10px;
+}
+
+.container :global(.ant-table-cell).cell-line-id {
+    padding: 0px;
 }
 
 .snp-column {

--- a/src/style/table.module.css
+++ b/src/style/table.module.css
@@ -10,9 +10,9 @@
 }
 
 .thumbnail-container {
-    width: 100%;
-    height: 100%;
     position: absolute; 
+    top: 0;
+    left: 0;
 }
 
 .id-header {
@@ -101,12 +101,9 @@
     padding: 14px 16px;
 }
 
-.container :global(.ant-table-thead .ant-table-cell).cell-line-id {
-    padding: 10px 16px 10px;
-}
-
+.container :global(.ant-table-thead .ant-table-cell).cell-line-id,
 .container :global(.ant-table-cell).cell-line-id {
-    padding: 0px;
+    padding: 10px 16px 10px;
 }
 
 .snp-column {

--- a/src/style/table.module.css
+++ b/src/style/table.module.css
@@ -10,13 +10,27 @@
 }
 
 .thumbnail-container {
-    width: 80px;
-    height: 60px;
-    overflow: hidden;
+    width: 100%;
+    height: 100%;
+    position: absolute; 
 }
 
-.container :global(.ant-table) {
-    border-radius: 4px;
+.id-column {
+    position: relative;
+    width: 100%; 
+    height: 100%; 
+    min-height: 80px;
+}
+
+.id-header {
+    position: absolute;
+    top: 0; 
+    left: 0;
+    right: 0; 
+    z-index: 2;
+    background-color: var(--WHITE);
+    opacity: 0.85;
+    text-align: center; 
 }
 
 .container :global(.ant-table-container) {

--- a/src/style/table.module.css
+++ b/src/style/table.module.css
@@ -9,6 +9,12 @@
     line-height: 0;
 }
 
+.thumbnail-container {
+    width: 80px;
+    height: 60px;
+    overflow: hidden;
+}
+
 .container :global(.ant-table) {
     border-radius: 4px;
 }

--- a/src/templates/cell-line.tsx
+++ b/src/templates/cell-line.tsx
@@ -97,7 +97,7 @@ export const pageQuery = graphql`
                 status
                 thumbnail_image {
                     childImageSharp {
-                        gatsbyImageData(placeholder: BLURRED, width: 164)
+                        gatsbyImageData(placeholder: BLURRED)
                     }
                 }
             }

--- a/src/templates/cell-line.tsx
+++ b/src/templates/cell-line.tsx
@@ -97,7 +97,7 @@ export const pageQuery = graphql`
                 status
                 thumbnail_image {
                     childImageSharp {
-                        gatsbyImageData(placeholder: BLURRED)
+                        gatsbyImageData(width: 200, placeholder: BLURRED)
                     }
                 }
             }

--- a/src/templates/cell-line.tsx
+++ b/src/templates/cell-line.tsx
@@ -97,7 +97,7 @@ export const pageQuery = graphql`
                 status
                 thumbnail_image {
                     childImageSharp {
-                        gatsbyImageData(width: 200, placeholder: BLURRED)
+                        gatsbyImageData(placeholder: BLURRED, width: 164)
                     }
                 }
             }


### PR DESCRIPTION
Problem
=======
What is the problem this work solves, including
closes #167 

Solution
========
What I/we did to solve this problem
- added static thumbnail images to cell line main table

Next steps: 
- add hover effects
- move the rest of thumbnails over from the legacy cell catalog 

with @interim17 

Note: I removed `width: 164` from the first columns in this pr as there are other unmatched sizing in the table. Might be cleaner to take care of sizing issues in a separate pr.

## Type of change
Please delete options that are not relevant.

* New feature (non-breaking change which adds functionality)
