### PR TITLE
Render thumbnails for cell line main table

### DIFF
--- a/src/component-queries/NormalCellLines.tsx
+++ b/src/component-queries/NormalCellLines.tsx
@@ -96,6 +96,14 @@ export default function NormalCellLines() {
                                     status
                                     order_link
                                     donor_plasmid
+                                    thumbnail_image {
+                                        childImageSharp {
+                                            gatsbyImageData(
+                                                placeholder: BLURRED
+                                                width: 164
+                                            )
+                                        }
+                                    }
                                     genetic_modifications {
                                         gene {
                                             frontmatter {

--- a/src/component-queries/convert-data.ts
+++ b/src/component-queries/convert-data.ts
@@ -105,6 +105,7 @@ export const convertFrontmatterToNormalCellLines = ({
         healthCertificate: "",
         orderLink: cellLineNode.frontmatter.order_link,
         orderPlasmid: cellLineNode.frontmatter.donor_plasmid,
+        thumbnailImage: cellLineNode.frontmatter.thumbnail_image,
     };
 };
 

--- a/src/component-queries/types.ts
+++ b/src/component-queries/types.ts
@@ -49,6 +49,7 @@ export interface NormalCellLineFrontmatter {
     tag_location: string[];
     fluorescent_tag: string[];
     donor_plasmid: string;
+    thumbnail_image: FileNode;
     parental_line: {
         frontmatter: {
             name: string;
@@ -205,6 +206,7 @@ export interface UnpackedNormalCellLine extends UnpackedCellLineMainInfo {
     tagLocation: string[];
     fluorescentTag: string[];
     orderPlasmid: string;
+    thumbnailImage: FileNode;
 }
 
 export type ParentLine = Partial<UnpackedNormalCellLine>;

--- a/src/components/CellLineTable/DiseaseTableColumns.tsx
+++ b/src/components/CellLineTable/DiseaseTableColumns.tsx
@@ -1,12 +1,14 @@
 import React from "react";
 import { Flex } from "antd";
 import classNames from "classnames";
+import { Link } from "gatsby";
 
 import {
     Clone,
     UnpackedDiseaseCellLine,
     UnpackedGene,
     UnpackedNormalCellLine,
+    CellLineStatus,
 } from "../../component-queries/types";
 import { formatCellLineId, getCloneSummary } from "../../utils";
 import GeneDisplay from "../GeneDisplay";
@@ -14,17 +16,37 @@ import ParentalLineModal from "../ParentalLineModal";
 import CloneSummary from "../CloneSummary";
 
 import {
-    cellLineIdColumn,
     certificateOfAnalysisColumn,
     obtainLineColumn,
 } from "./SharedColumns";
-import { smBreakPoint, mdBreakpoint, CellLineColumns } from "./types";
+import { smBreakPoint, mdBreakpoint, CellLineColumns, UnpackedCellLine } from "./types";
 
 const {
     clones,
     lastColumn,
     snpColumn,
+    cellLineId,
 } = require("../../style/table.module.css");
+
+const cellLineIdColumn = {
+    title: "Cell Collection ID",
+    key: "cellLineId",
+    className: cellLineId,
+    dataIndex: "cellLineId",
+    fixed: "left" as const,
+    render: (cellLineId: number, record: UnpackedCellLine) => {
+        const cellLine = (
+            <h4 key={cellLineId}>{formatCellLineId(cellLineId)}</h4>
+        );
+        return record.status === CellLineStatus.DataComplete ? (
+            <Link to={record.path}>
+                {cellLine}
+            </Link>
+        ) : (
+            cellLine
+        );
+    },
+};
 
 export const getDiseaseTableColumns = (
     inProgress: boolean

--- a/src/components/CellLineTable/NormalTableColumns.tsx
+++ b/src/components/CellLineTable/NormalTableColumns.tsx
@@ -2,15 +2,19 @@ import React from "react";
 import { Flex } from "antd";
 import Icon, { CaretDownOutlined, CaretUpOutlined } from "@ant-design/icons";
 import { SortOrder } from "antd/es/table/interface";
+import { GatsbyImage, getImage } from "gatsby-plugin-image";
+import { Link } from "gatsby";
 
 import {
     UnpackedGene,
     UnpackedNormalCellLine,
+    CellLineStatus,
 } from "../../component-queries/types";
 import { RAIN_SHADOW, SERIOUS_GRAY } from "../../style/theme";
 import GeneDisplay from "../GeneDisplay";
-import { cellLineIdColumn, obtainLineColumn } from "./SharedColumns";
-import { CellLineColumns, mdBreakpoint } from "./types";
+import { obtainLineColumn } from "./SharedColumns";
+import { CellLineColumns, mdBreakpoint, UnpackedCellLine } from "./types";
+import { formatCellLineId } from "../../utils";
 
 const Plasmid = require("../../img/plasmid.svg");
 
@@ -19,6 +23,9 @@ const {
     actionColumn,
     actionButton,
     plasmidIcon,
+    cellLineId,
+    thumbnailContainer,
+    idHeader,
 } = require("../../style/table.module.css");
 
 const caseInsensitiveStringCompare = (a = "", b = "") =>
@@ -35,6 +42,42 @@ const sortIcon = ({ sortOrder }: { sortOrder: SortOrder }) => {
     ) : (
         <CaretUpOutlined style={{ color: SERIOUS_GRAY, fontSize: 16 }} />
     );
+};
+
+const cellLineIdColumn = {
+    title: "Cell Collection ID",
+    key: "cellLineId",
+    className: cellLineId,
+    dataIndex: "cellLineId",
+    fixed: "left" as const,
+    render: (cellLineId: number, record: UnpackedCellLine) => {
+        const formattedId = formatCellLineId(cellLineId);
+        const cellLine = (
+            <h4 key={cellLineId}>{formattedId}</h4>
+        );
+        const thumbnailImage = record.thumbnailImage?.childImageSharp?.gatsbyImageData ?
+            getImage(record.thumbnailImage.childImageSharp.gatsbyImageData) : null;
+        const content = (
+            <>
+                <div className={idHeader}>{cellLine}</div>
+                {thumbnailImage && (
+                    <div className={thumbnailContainer}>
+                        <GatsbyImage
+                            image={thumbnailImage}
+                            alt={`${formattedId} thumbnail`}
+                        />
+                    </div>
+                )}
+            </>
+        );
+        return record.status === CellLineStatus.DataComplete ? (
+            <Link to={record.path}>
+                {content}
+            </Link>
+        ) : (
+            content
+        );
+    },
 };
 
 const obtainPlasmidColumn = {

--- a/src/components/CellLineTable/SharedColumns.tsx
+++ b/src/components/CellLineTable/SharedColumns.tsx
@@ -1,40 +1,18 @@
-import { Link } from "gatsby";
 import React from "react";
 import { Flex } from "antd";
 import Icon from "@ant-design/icons";
 
-import { CellLineStatus } from "../../component-queries/types";
-import { formatCellLineId } from "../../utils";
 import { WHITE } from "../../style/theme";
-import { mdBreakpoint, UnpackedCellLine } from "./types";
+import { mdBreakpoint } from "./types";
 
 const CertificateIcon = require("../../img/cert-icon.svg");
 const Tube = require("../../img/tube.svg");
 
 const {
-    cellLineId,
     actionColumn,
     actionButton,
     tubeIcon,
 } = require("../../style/table.module.css");
-
-export const cellLineIdColumn = {
-    title: "Cell Collection ID",
-    key: "cellLineId",
-    className: cellLineId,
-    dataIndex: "cellLineId",
-    fixed: "left" as const,
-    render: (cellLineId: number, record: UnpackedCellLine) => {
-        const cellLine = (
-            <h4 key={cellLineId}>{formatCellLineId(cellLineId)}</h4>
-        );
-        return record.status === CellLineStatus.DataComplete ? (
-            <Link to={record.path}>{cellLine}</Link>
-        ) : (
-            cellLine
-        );
-    },
-};
 
 export const certificateOfAnalysisColumn = {
     title: "",

--- a/src/style/table.module.css
+++ b/src/style/table.module.css
@@ -9,6 +9,27 @@
     line-height: 0;
 }
 
+.thumbnail-container {
+    position: absolute;
+    top: 0;
+    left: 0;
+}
+
+.id-header {
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    z-index: 2;
+    background-color: var(--WHITE);
+    opacity: 0.85;
+    text-align: center;
+}
+
+.container .id-header h4 {
+    margin: 0px;
+}
+
 .container :global(.ant-table) {
     border-radius: 4px;
 }


### PR DESCRIPTION
Problem
=======
What is the problem this work solves, including
closes #167 

Solution
========
What I/we did to solve this problem
- added static thumbnail images to cell line main table

Next steps: 
- add hover effects
- move the rest of thumbnails over from the legacy cell catalog 

with @interim17 

Note: I removed `width: 164` from the first columns in this pr as there are other unmatched sizing in the table. Might be cleaner to take care of sizing issues in a separate pr.
<img width="1199" alt="Screenshot 2025-05-29 at 7 05 24 PM" src="https://github.com/user-attachments/assets/220d271a-21c4-4c7c-bb58-8bc372983b55" />


## Type of change
Please delete options that are not relevant.

* New feature (non-breaking change which adds functionality)