### PR TITLE
update some admin data fields to optional

### DIFF
--- a/static/admin/config.yml
+++ b/static/admin/config.yml
@@ -169,6 +169,7 @@ collections:
                             label: "Images",
                             name: "images",
                             widget: "list",
+                            required: false,
                             fields:
                                 [
                                     {
@@ -180,6 +181,7 @@ collections:
                                         label: "Caption",
                                         name: "caption",
                                         widget: "string",
+                                        required: false,
                                     },
                                 ],
                         },
@@ -187,6 +189,7 @@ collections:
                             label: "Videos",
                             name: "videos",
                             widget: "list",
+                            required: false,
                             fields:
                                 [
                                     {
@@ -198,6 +201,7 @@ collections:
                                         label: "Caption",
                                         name: "caption",
                                         widget: "string",
+                                        required: false,
                                     },
                                 ],
                         },
@@ -387,6 +391,7 @@ collections:
                             label: "Images",
                             name: "images",
                             widget: "list",
+                            required: false,
                             fields:
                                 [
                                     {
@@ -398,6 +403,7 @@ collections:
                                         label: "Caption",
                                         name: "caption",
                                         widget: "string",
+                                        required: false,
                                     },
                                 ],
                         },
@@ -405,6 +411,7 @@ collections:
                             label: "Videos",
                             name: "videos",
                             widget: "list",
+                            required: false,
                             fields:
                                 [
                                     {
@@ -416,6 +423,7 @@ collections:
                                         label: "Caption",
                                         name: "caption",
                                         widget: "string",
+                                        required: false,
                                     },
                                 ],
                         },
@@ -441,6 +449,7 @@ collections:
                                         label: "Title",
                                         name: "title",
                                         widget: "string",
+                                        required: false,
                                     },
                                     {
                                         label: "Image",
@@ -451,6 +460,7 @@ collections:
                                         label: "Caption",
                                         name: "caption",
                                         widget: "string",
+                                        required: false,
                                     },
                                 ],
                         },
@@ -489,6 +499,7 @@ collections:
                                         label: "Type",
                                         name: "type",
                                         widget: "select",
+                                        required: false,
                                         default: "",
                                         options: ["", "WT", "Mutant"],
                                     },


### PR DESCRIPTION
Problem
=======
What is the problem this work solves, including
Admin page blocks changes from being submitted when required data fields are left blank 

Solution
========
What I/we did to solve this problem

added `required: false` to several fields to prevent submission errors. 

## Type of change
Please delete options that are not relevant.

* Data Update (non-breaking change which fixes an issue)



