### PR TITLE
about section

### DIFF
--- a/src/components/About.tsx
+++ b/src/components/About.tsx
@@ -1,0 +1,71 @@
+import React from "react";
+
+const { container, italic, firstBlock, diseaseCopy } = require("../style/about.module.css");
+
+interface AboutProps {
+    primary_text: string;
+    emphasis_text: string;
+    newsletter_text: string;
+    disease_catalog_copy: string;
+    links: {
+        newsletter: {
+            url: string;
+            text: string;
+        };
+        disease_catalog: {
+            url: string;
+            text: string;
+        };
+    };
+}
+
+const processTextWithLinks = (
+    text: string,
+    links: Record<string, { text: string; url: string }>
+) => {
+    let processedText = text;
+
+    Object.entries(links).forEach(([key, link]) => {
+        processedText = processedText.replace(
+            link.text,
+            `<a href="${link.url}">${link.text}</a>`
+        );
+    });
+    return <div dangerouslySetInnerHTML={{ __html: processedText }} />;
+};
+
+const processTextWithEmphasis = (text: string, emphasis: string) => {
+    let processedText = text;
+    processedText = processedText.replace(
+        emphasis,
+        `<span class="${italic}">${emphasis}</span>`
+    );
+    return <div dangerouslySetInnerHTML={{ __html: processedText }} />;
+};
+
+const About: React.FC<AboutProps> = ({
+    primary_text,
+    emphasis_text,
+    newsletter_text,
+    disease_catalog_copy,
+    links,
+}) => {
+    const primaryText = processTextWithEmphasis(primary_text, emphasis_text);
+    const newsletterText = processTextWithLinks(newsletter_text, {
+        newsletter: links.newsletter,
+    });
+    const diseaseCatalogCopy = processTextWithLinks(disease_catalog_copy, {
+        disease_catalog: links.disease_catalog,
+    });
+    return (
+        <div className={container}>
+            <div className={firstBlock}>
+                <div>{primaryText}</div>
+                <div>{newsletterText}</div>
+            </div>
+            <div className={diseaseCopy}>{diseaseCatalogCopy}</div>
+        </div>
+    );
+};
+
+export default About;

--- a/src/components/About.tsx
+++ b/src/components/About.tsx
@@ -3,16 +3,16 @@ import React from "react";
 const { container, italic, firstBlock, diseaseCopy } = require("../style/about.module.css");
 
 interface AboutProps {
-    primary_text: string;
-    emphasis_text: string;
-    newsletter_text: string;
-    disease_catalog_copy: string;
+    primary: string;
+    emphasis: string;
+    newsletter: string;
+    disease: string;
     links: {
         newsletter: {
             url: string;
             text: string;
         };
-        disease_catalog: {
+        disease: {
             url: string;
             text: string;
         };
@@ -44,23 +44,23 @@ const processTextWithEmphasis = (text: string, emphasis: string) => {
 };
 
 const About: React.FC<AboutProps> = ({
-    primary_text,
-    emphasis_text,
-    newsletter_text,
-    disease_catalog_copy,
+    primary,
+    emphasis,
+    newsletter,
+    disease,
     links,
 }) => {
-    const primaryText = processTextWithEmphasis(primary_text, emphasis_text);
-    const newsletterText = processTextWithLinks(newsletter_text, {
+    const primaryTextWithEmphasis = processTextWithEmphasis(primary, emphasis);
+    const newsletterText = processTextWithLinks(newsletter, {
         newsletter: links.newsletter,
     });
-    const diseaseCatalogCopy = processTextWithLinks(disease_catalog_copy, {
-        disease_catalog: links.disease_catalog,
+    const diseaseCatalogCopy = processTextWithLinks(disease, {
+        disease_catalog: links.disease,
     });
     return (
         <div className={container}>
             <div className={firstBlock}>
-                <div>{primaryText}</div>
+                <div>{primaryTextWithEmphasis}</div>
                 <div>{newsletterText}</div>
             </div>
             <div className={diseaseCopy}>{diseaseCatalogCopy}</div>

--- a/src/pages/normal-catalog/index.md
+++ b/src/pages/normal-catalog/index.md
@@ -16,6 +16,7 @@ about_block:
     disease_catalog:
       text: "Check out our Disease Cell Catalog"
       url: "https://www.allencell.org/cell-catalog/disease-catalog"
+table_header: "Allen Cell Collection Cell Lines"
 coriell_image: /img/coriell.png
 coriell_link: https://www.coriell.org/1/AllenCellCollection
 acknowledgements_block:

--- a/src/pages/normal-catalog/index.md
+++ b/src/pages/normal-catalog/index.md
@@ -1,6 +1,21 @@
 ---
 templateKey: normal-catalog
 title: About the Collection
+about_block: 
+  primary_text: >
+    The Allen Cell Collection contains over one hundred high quality, certified fluorescently tagged hiPSC lines that target dozens of key cellular structures and substructures. These cell lines and their editing plasmids are openly available to academic and commercial researchers through Coriell and Addgene respectively.
+  emphasis_text: Allen Cell Collection
+  newsletter_text: >
+      New lines are released frequently. Subscribe to our newsletter to stay current with out latest releases.
+  disease_catalog_copy: >
+    Looking for a line with a disease mutation? Check out our Disease Cell Catalog.
+  links:
+    newsletter:
+      text: "Subscribe to our newsletter"
+      url: "https://www.alleninstitute.org/newsletter"
+    disease_catalog:
+      text: "Check out our Disease Cell Catalog"
+      url: "https://www.allencell.org/cell-catalog/disease-catalog"
 coriell_image: /img/coriell.png
 coriell_link: https://www.coriell.org/1/AllenCellCollection
 acknowledgements_block:
@@ -22,5 +37,3 @@ funding_text: >
 
   We wish to thank Allen Institute founders, Jody Allen & Paul G. Allen, for their vision, encouragement, and support.
 ---
-
-[Subscribe to our newsletter](https://www.alleninstitute.org/newsletter) to stay informed of frequently released new cell lines.

--- a/src/pages/normal-catalog/index.md
+++ b/src/pages/normal-catalog/index.md
@@ -2,18 +2,18 @@
 templateKey: normal-catalog
 title: About the Collection
 about_block: 
-  primary_text: >
+  primary: >
     The Allen Cell Collection contains over one hundred high quality, certified fluorescently tagged hiPSC lines that target dozens of key cellular structures and substructures. These cell lines and their editing plasmids are openly available to academic and commercial researchers through Coriell and Addgene respectively.
-  emphasis_text: Allen Cell Collection
-  newsletter_text: >
+  emphasis: Allen Cell Collection
+  newsletter: >
       New lines are released frequently. Subscribe to our newsletter to stay current with out latest releases.
-  disease_catalog_copy: >
+  disease: >
     Looking for a line with a disease mutation? Check out our Disease Cell Catalog.
   links:
     newsletter:
       text: "Subscribe to our newsletter"
       url: "https://www.alleninstitute.org/newsletter"
-    disease_catalog:
+    disease:
       text: "Check out our Disease Cell Catalog"
       url: "https://www.allencell.org/cell-catalog/disease-catalog"
 table_header: "Allen Cell Collection Cell Lines"

--- a/src/style/about.module.css
+++ b/src/style/about.module.css
@@ -1,0 +1,22 @@
+.container {
+    display: flex;
+    flex-direction: column;
+    font-size: 20px;
+    gap: 40px;
+    line-height: 1.75;
+}
+
+.first-block {
+    display: flex;
+    flex-direction: column;
+    gap: 34px;
+}
+
+.italic {
+    font-style: italic;
+}
+
+.disease-copy {
+    font-size: 24px;
+    font-weight: 600;
+}

--- a/src/templates/normal-catalog.tsx
+++ b/src/templates/normal-catalog.tsx
@@ -7,6 +7,7 @@ import Content, { HTMLContent } from "../components/shared/Content";
 import { GatsbyImage, getImage } from "gatsby-plugin-image";
 import { FileNode } from "gatsby-plugin-image/dist/src/components/hooks";
 import NormalCellLines from "../component-queries/NormalCellLines";
+import About from "../components/About";
 
 const {
     container,
@@ -16,6 +17,22 @@ const {
 } = require("../style/catalog.module.css");
 interface NormalCatalogTemplateProps {
     title: string;
+    aboutBlock: {
+        primary_text: string;
+        emphasis_text: string;
+        newsletter_text: string;
+        disease_catalog_copy: string;
+        links: {
+            newsletter: {
+                url: string;
+                text: string;
+            };
+            disease_catalog: {
+                url: string;
+                text: string;
+            };
+        };
+    };
     content: string;
     contentComponent?: JSX.ElementType;
     fundingText: string;
@@ -36,6 +53,7 @@ export const NormalCatalogTemplate = ({
     acknowledgementsBlock,
     coriellImage,
     coriellLink,
+    aboutBlock,
 }: NormalCatalogTemplateProps) => {
     const image = getImage(coriellImage);
     const PageContent = contentComponent || Content;
@@ -44,6 +62,7 @@ export const NormalCatalogTemplate = ({
             <h1>{title}</h1>
             <Flex className={header}>
                 <PageContent className="content" content={content} />
+                <About {...aboutBlock} />
                 <Divider
                     type="vertical"
                     style={{ height: "initial", marginInline: "20px" }}
@@ -81,6 +100,22 @@ interface QueryResult {
                 footer_text: {
                     html: string;
                 };
+                about_block: {
+                    primary_text: string;
+                    emphasis_text: string;
+                    newsletter_text: string;
+                    disease_catalog_copy: string;
+                    links: {
+                        newsletter: {
+                            url: string;
+                            text: string;
+                        };
+                        disease_catalog: {
+                            url: string;
+                            text: string;
+                        };
+                    };
+                };
                 funding_text: {
                     html: string;
                 };
@@ -102,6 +137,7 @@ const NormalCatalog = ({ data }: QueryResult) => {
         <Layout>
             <NormalCatalogTemplate
                 contentComponent={HTMLContent}
+                aboutBlock={post.frontmatter.about_block}
                 title={post.frontmatter.title}
                 content={post.html}
                 fundingText={post.frontmatter.funding_text.html}
@@ -123,6 +159,22 @@ export const aboutPageQuery = graphql`
                 title
                 funding_text {
                     html
+                }
+                about_block {
+                    primary_text
+                    emphasis_text
+                    newsletter_text
+                    disease_catalog_copy
+                    links {
+                       newsletter {
+                            text
+                            url
+                        }
+                        disease_catalog {
+                            text
+                            url
+                        }
+                    }
                 }
                 acknowledgements_block {
                     intro

--- a/src/templates/normal-catalog.tsx
+++ b/src/templates/normal-catalog.tsx
@@ -19,16 +19,16 @@ const {
 interface NormalCatalogTemplateProps {
     title: string;
     aboutBlock: {
-        primary_text: string;
-        emphasis_text: string;
-        newsletter_text: string;
-        disease_catalog_copy: string;
+        primary: string;
+        emphasis: string;
+        newsletter: string;
+        disease: string;
         links: {
             newsletter: {
                 url: string;
                 text: string;
             };
-            disease_catalog: {
+            disease: {
                 url: string;
                 text: string;
             };
@@ -65,7 +65,7 @@ export const NormalCatalogTemplate = ({
             <h1>{title}</h1>
             <Flex className={header}>
                 <PageContent className="content" content={content} />
-                <About {...aboutBlock} />
+                <About {...aboutBlock}/>
                 <Divider
                     type="vertical"
                     style={{ height: "initial", marginInline: "20px" }}
@@ -105,16 +105,16 @@ interface QueryResult {
                     html: string;
                 };
                 about_block: {
-                    primary_text: string;
-                    emphasis_text: string;
-                    newsletter_text: string;
-                    disease_catalog_copy: string;
+                    primary: string;
+                    emphasis: string;
+                    newsletter: string;
+                    disease: string;
                     links: {
                         newsletter: {
                             url: string;
                             text: string;
                         };
-                        disease_catalog: {
+                        disease: {
                             url: string;
                             text: string;
                         };
@@ -167,16 +167,16 @@ export const aboutPageQuery = graphql`
                     html
                 }
                 about_block {
-                    primary_text
-                    emphasis_text
-                    newsletter_text
-                    disease_catalog_copy
+                    primary
+                    emphasis
+                    newsletter
+                    disease
                     links {
                        newsletter {
                             text
                             url
                         }
-                        disease_catalog {
+                        disease {
                             text
                             url
                         }

--- a/src/templates/normal-catalog.tsx
+++ b/src/templates/normal-catalog.tsx
@@ -14,6 +14,7 @@ const {
     coriellCard,
     header,
     coriellWrapper,
+    mainHeading,
 } = require("../style/catalog.module.css");
 interface NormalCatalogTemplateProps {
     title: string;
@@ -43,6 +44,7 @@ interface NormalCatalogTemplateProps {
     };
     coriellImage: FileNode;
     coriellLink: string;
+    tableHeader: string
 }
 // eslint-disable-next-line
 export const NormalCatalogTemplate = ({
@@ -54,6 +56,7 @@ export const NormalCatalogTemplate = ({
     coriellImage,
     coriellLink,
     aboutBlock,
+    tableHeader
 }: NormalCatalogTemplateProps) => {
     const image = getImage(coriellImage);
     const PageContent = contentComponent || Content;
@@ -82,6 +85,7 @@ export const NormalCatalogTemplate = ({
                     )}
                 </div>
             </Flex>
+            <h2 className={mainHeading}>{tableHeader}</h2>
             <NormalCellLines />
             <Footer
                 acknowledgementsBlock={acknowledgementsBlock}
@@ -126,6 +130,7 @@ interface QueryResult {
                 };
                 coriell_image: FileNode;
                 coriell_link: string;
+                table_header: string;
             };
         };
     };
@@ -144,6 +149,7 @@ const NormalCatalog = ({ data }: QueryResult) => {
                 acknowledgementsBlock={post.frontmatter.acknowledgements_block}
                 coriellImage={post.frontmatter.coriell_image}
                 coriellLink={post.frontmatter.coriell_link}
+                tableHeader={post.frontmatter.table_header}
             />
         </Layout>
     );
@@ -176,6 +182,7 @@ export const aboutPageQuery = graphql`
                         }
                     }
                 }
+                table_header
                 acknowledgements_block {
                     intro
                     contributors {

--- a/static/admin/config.yml
+++ b/static/admin/config.yml
@@ -752,6 +752,53 @@ collections:
                       default: "normal-catalog",
                   }
                 - { label: "Title", name: "title", widget: "string" }
+                - {
+                    label: "About Block",
+                    name: "about_block",
+                    widget: "object",
+                    fields: [
+                        {
+                            label: "Primary Text",
+                            name: "primary_text",
+                            widget: "text"
+                        },
+                        {
+                            label: "Newsletter Text",
+                            name: "newsletter_text",
+                            widget: "text"
+                        },
+                        {
+                            label: "Disease Catalog Copy",
+                            name: "disease_catalog_copy",
+                            widget: "text"
+                        },
+                        {
+                            label: "Links",
+                            name: "links",
+                            widget: "object",
+                            fields: [
+                                {
+                                    label: "Newsletter Link",
+                                    name: "newsletter",
+                                    widget: "object",
+                                    fields: [
+                                        { label: "Text", name: "text", widget: "string" },
+                                        { label: "URL", name: "url", widget: "string" }
+                                    ]
+                                },
+                                {
+                                    label: "Disease Catalog Link",
+                                    name: "disease_catalog",
+                                    widget: "object",
+                                    fields: [
+                                        { label: "Text", name: "text", widget: "string" },
+                                        { label: "URL", name: "url", widget: "string" }
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                }
                 - { label: "Body", name: "body", widget: "markdown" }
                 - {
                       label: "Main",

--- a/static/admin/config.yml
+++ b/static/admin/config.yml
@@ -759,17 +759,22 @@ collections:
                     fields: [
                         {
                             label: "Primary Text",
-                            name: "primary_text",
+                            name: "primary",
+                            widget: "text"
+                        },
+                                                {
+                            label: "Primary emphasis Text",
+                            name: "emphasis",
                             widget: "text"
                         },
                         {
                             label: "Newsletter Text",
-                            name: "newsletter_text",
+                            name: "newsletter",
                             widget: "text"
                         },
                         {
                             label: "Disease Catalog Copy",
-                            name: "disease_catalog_copy",
+                            name: "disease",
                             widget: "text"
                         },
                         {
@@ -788,7 +793,7 @@ collections:
                                 },
                                 {
                                     label: "Disease Catalog Link",
-                                    name: "disease_catalog",
+                                    name: "disease",
                                     widget: "object",
                                     fields: [
                                         { label: "Text", name: "text", widget: "string" },


### PR DESCRIPTION
Problem
=======
Advances #163 

Solution
========
Add text and links for About section and table header to config/markdown.

* New feature (non-breaking change which adds functionality)

<img width="1422" alt="Screenshot 2025-06-04 at 9 51 41 AM" src="https://github.com/user-attachments/assets/afc0b14a-8022-438c-9c2d-124bb0cfcf79" />

