### PR TITLE
about section: component query version

### DIFF
--- a/src/component-queries/About.tsx
+++ b/src/component-queries/About.tsx
@@ -1,0 +1,120 @@
+import React from "react";
+import { StaticQuery, graphql } from "gatsby";
+
+const {
+    container,
+    section,
+    italic,
+    firstBlock,
+    diseaseCopy,
+    primaryText,
+} = require("../style/about.module.css");
+
+interface AboutProps {
+    markdownRemark: {
+        frontmatter: {
+            about_block: {
+                primary: string;
+                emphasis: string;
+                newsletter: string;
+                disease: string;
+                links: {
+                    newsletter: { url: string; text: string };
+                    disease: { url: string; text: string };
+                };
+            };
+        };
+    };
+}
+
+const About: React.FC = () => {
+    return (
+        <StaticQuery
+            query={graphql`
+                query AboutQuery {
+                    markdownRemark(
+                        frontmatter: { templateKey: { eq: "normal-catalog" } }
+                    ) {
+                        frontmatter {
+                            about_block {
+                                primary
+                                emphasis
+                                newsletter
+                                disease
+                                links {
+                                    newsletter {
+                                        text
+                                        url
+                                    }
+                                    disease {
+                                        text
+                                        url
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            `}
+            render={(data: AboutProps) => {
+                const {
+                    about_block
+                } = data.markdownRemark.frontmatter;
+
+                /**
+                 * Helper function to add links or emphasis to text.
+                 * @param text text to process
+                 * @param find string to find in the text
+                 * @param replace html string to replace the find string with
+                 * @returns
+                 */
+                const processText = (
+                    text: string,
+                    find: string,
+                    replace: string
+                ) => {
+                    let processed = text;
+                    processed = processed.replace(find, replace);
+                    return (
+                        <div dangerouslySetInnerHTML={{ __html: processed }} />
+                    );
+                };
+
+                const primaryTextWithEmphasis = processText(
+                    about_block.primary,
+                    about_block.emphasis,
+                    `<span class="${italic}">${about_block.emphasis}</span>`
+                );
+                const newsletterTextWithLink = processText(
+                    about_block.newsletter,
+                    about_block.links.newsletter.text,
+                    `<a href="${about_block.links.newsletter.url}">${about_block.links.newsletter.text}</a>`
+                );
+                const diseaseCopyWithLink = processText(
+                    about_block.disease,
+                    about_block.links.disease.text,
+                    `<a href="${about_block.links.disease.url}">${about_block.links.disease.text}</a>`
+                );
+
+                return (
+                    <div className={container}>
+                        <div className={section}>
+                            <div className={firstBlock}>
+                                <div className={primaryText}>
+                                    <h1> About the collection </h1>
+                                    <div>{primaryTextWithEmphasis}</div>
+                                </div>
+                                <div>{newsletterTextWithLink}</div>
+                            </div>
+                            <div className={diseaseCopy}>
+                                {diseaseCopyWithLink}
+                            </div>
+                        </div>
+                    </div>
+                );
+            }}
+        />
+    );
+};
+
+export default About;

--- a/src/pages/normal-catalog/index.md
+++ b/src/pages/normal-catalog/index.md
@@ -1,9 +1,22 @@
 ---
 templateKey: normal-catalog
 title: About the Collection
-main:
-  heading: Allen Cell Collection Cell Lines
-  description: ""
+about_block: 
+  primary: >
+    The Allen Cell Collection contains over one hundred high quality, certified fluorescently tagged hiPSC lines that target dozens of key cellular structures and substructures. These cell lines and their editing plasmids are openly available to academic and commercial researchers through Coriell and Addgene respectively.
+  emphasis: Allen Cell Collection
+  newsletter: >
+      New lines are released frequently. Subscribe to our newsletter to stay current with out latest releases.
+  disease: >
+    Looking for a line with a disease mutation? Check out our Disease Cell Catalog.
+  links:
+    newsletter:
+      text: "Subscribe to our newsletter"
+      url: "https://www.alleninstitute.org/newsletter"
+    disease:
+      text: "Check out our Disease Cell Catalog"
+      url: "https://www.allencell.org/cell-catalog/disease-catalog"
+table_header: "Allen Cell Collection Cell Lines"
 coriell_image: /img/coriell.png
 coriell_link: https://www.coriell.org/1/AllenCellCollection
 acknowledgements_block:
@@ -25,5 +38,3 @@ funding_text: >
 
   We wish to thank Allen Institute founders, Jody Allen & Paul G. Allen, for their vision, encouragement, and support.
 ---
-
-[Subscribe to our newsletter](https://www.alleninstitute.org/newsletter) to stay informed of frequently released new cell lines.

--- a/src/pages/normal-catalog/index.md
+++ b/src/pages/normal-catalog/index.md
@@ -15,7 +15,7 @@ about_block:
       url: "https://www.alleninstitute.org/newsletter"
     disease:
       text: "Check out our Disease Cell Catalog"
-      url: "https://www.allencell.org/cell-catalog/disease-catalog"
+      url: "https://cell-catalog.allencell.org/disease-catalog/"
 table_header: "Allen Cell Collection Cell Lines"
 coriell_image: /img/coriell.png
 coriell_link: https://www.coriell.org/1/AllenCellCollection

--- a/src/style/about.module.css
+++ b/src/style/about.module.css
@@ -1,0 +1,37 @@
+.container {
+    display: flex;
+    gap: 48px;
+}
+
+.section {
+    display: flex;
+    flex-direction: column;
+    font-size: 20px;
+    gap: 40px;
+    line-height: 1.75;
+}
+
+.section h1 {
+    font-size: 33px;
+}
+
+.first-block {
+    display: flex;
+    flex-direction: column;
+    gap: 34px;
+}
+
+.primary-text {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+}
+
+.italic {
+    font-style: italic;
+}
+
+.disease-copy {
+    font-size: 24px;
+    font-weight: 600;
+}

--- a/src/style/catalog.module.css
+++ b/src/style/catalog.module.css
@@ -21,45 +21,12 @@
 .header a {
     color: var(--link-color);
 }
-
-.coriell-wrapper {
-    margin: auto;
-}
-
-.coriell-card {
-    box-sizing: border-box;
-    width: 250px;
-    border: 1px solid var(--border-color);
-}
-
-.coriell-card:hover {
-    border: solid 1.5px var(--primary-color);
-}
-
-.coriell-card :global(.ant-card-head) {
-    font-family: "Open Sans";
-    font-size: 16px;
-    font-weight: 600;
-    text-align: center;
-    border-bottom: none;
-}
-
-.coriell-card :global(.ant-card-head) {
-    color: var(--primary-color);
-    padding: 9px 0 0 0;
-    min-height: inherit;
-}
-
-.coriell-card :global(.gatsby-image-wrapper) {
-    margin: auto;
-}
-
-.coriell-card :global(.ant-card-body) {
-    padding: 9px;
-}
-
 .main-heading {
     color: var(--primary-color);
+}
+
+.normal.main-heading {
+    margin-top: 56px;
 }
 
 .banner:global(.ant-card) {

--- a/src/templates/normal-catalog.tsx
+++ b/src/templates/normal-catalog.tsx
@@ -1,78 +1,42 @@
 import React from "react";
-import { Card, Divider, Flex } from "antd";
+import { Divider, Flex } from "antd";
 import { graphql } from "gatsby";
+import classNames from "classnames";
 import Layout from "../components/Layout";
 import Footer from "../components/Footer";
-import Content, { HTMLContent } from "../components/shared/Content";
-import { GatsbyImage, getImage } from "gatsby-plugin-image";
-import { FileNode } from "gatsby-plugin-image/dist/src/components/hooks";
 import NormalCellLines from "../component-queries/NormalCellLines";
+import About from "../component-queries/About";
 
 const {
     container,
-    coriellCard,
-    banner,
-    bannerContent,
     header,
     mainHeading,
-    coriellWrapper,
+    normal,
 } = require("../style/catalog.module.css");
 interface NormalCatalogTemplateProps {
     title: string;
     content: string;
-    contentComponent?: JSX.ElementType;
     fundingText: string;
     acknowledgementsBlock: {
         intro: string;
         contributors: { name: string; institution: string }[];
         outro: string;
     };
-    main: {
-        heading: string;
-        description: string;
-        subheading: string;
-    };
-    coriellImage: FileNode;
-    coriellLink: string;
+    tableHeader: string;
 }
-// eslint-disable-next-line
+
 export const NormalCatalogTemplate = ({
-    title,
-    content,
-    contentComponent,
     fundingText,
     acknowledgementsBlock,
-    main,
-    coriellImage,
-    coriellLink,
+    tableHeader,
 }: NormalCatalogTemplateProps) => {
-    const image = getImage(coriellImage);
-    const PageContent = contentComponent || Content;
     return (
         <section className={container}>
-            <h1>{title}</h1>
             <Flex className={header}>
-                <PageContent className="content" content={content} />
-                <Divider
-                    type="vertical"
-                    style={{ height: "initial", marginInline: "20px" }}
-                />
-                <div className={coriellWrapper}>
-                    {image && (
-                        <a href={coriellLink} target="_blank" rel="noreferrer">
-                            <Card
-                                bordered={true}
-                                className={coriellCard}
-                                title="View Allen Cell Collection on"
-                                cover={
-                                    <GatsbyImage image={image} alt="Coriell" />
-                                }
-                            ></Card>
-                        </a>
-                    )}
-                </div>
+                <About />
             </Flex>
-            <h2 className={mainHeading}>{main.heading}</h2>
+            <Divider />
+            <h2 className={classNames(normal, mainHeading)}>{tableHeader}</h2>
             <NormalCellLines />
             <Footer
                 acknowledgementsBlock={acknowledgementsBlock}
@@ -81,7 +45,7 @@ export const NormalCatalogTemplate = ({
         </section>
     );
 };
-// TODO: remove `main` content from the template and the query
+
 interface QueryResult {
     data: {
         markdownRemark: {
@@ -99,13 +63,7 @@ interface QueryResult {
                     contributors: { name: string; institution: string }[];
                     outro: string;
                 };
-                main: {
-                    heading: string;
-                    subheading: string;
-                    description: string;
-                };
-                coriell_image: FileNode;
-                coriell_link: string;
+                table_header: string;
             };
         };
     };
@@ -116,14 +74,11 @@ const NormalCatalog = ({ data }: QueryResult) => {
     return (
         <Layout>
             <NormalCatalogTemplate
-                contentComponent={HTMLContent}
                 title={post.frontmatter.title}
                 content={post.html}
                 fundingText={post.frontmatter.funding_text.html}
                 acknowledgementsBlock={post.frontmatter.acknowledgements_block}
-                main={post.frontmatter.main}
-                coriellImage={post.frontmatter.coriell_image}
-                coriellLink={post.frontmatter.coriell_link}
+                tableHeader={post.frontmatter.table_header}
             />
         </Layout>
     );
@@ -140,6 +95,7 @@ export const aboutPageQuery = graphql`
                 funding_text {
                     html
                 }
+                table_header
                 acknowledgements_block {
                     intro
                     contributors {
@@ -148,21 +104,6 @@ export const aboutPageQuery = graphql`
                     }
                     outro
                 }
-                main {
-                    heading
-                    subheading
-                    description
-                }
-                coriell_image {
-                    childImageSharp {
-                        gatsbyImageData(
-                            placeholder: BLURRED
-                            layout: FIXED
-                            width: 190
-                        )
-                    }
-                }
-                coriell_link
             }
         }
     }

--- a/static/admin/config.yml
+++ b/static/admin/config.yml
@@ -752,6 +752,58 @@ collections:
                       default: "normal-catalog",
                   }
                 - { label: "Title", name: "title", widget: "string" }
+                - {
+                    label: "About Block",
+                    name: "about_block",
+                    widget: "object",
+                    fields: [
+                        {
+                            label: "Primary Text",
+                            name: "primary",
+                            widget: "text"
+                        },
+                                                {
+                            label: "Primary emphasis Text",
+                            name: "emphasis",
+                            widget: "text"
+                        },
+                        {
+                            label: "Newsletter Text",
+                            name: "newsletter",
+                            widget: "text"
+                        },
+                        {
+                            label: "Disease Catalog Copy",
+                            name: "disease",
+                            widget: "text"
+                        },
+                        {
+                            label: "Links",
+                            name: "links",
+                            widget: "object",
+                            fields: [
+                                {
+                                    label: "Newsletter Link",
+                                    name: "newsletter",
+                                    widget: "object",
+                                    fields: [
+                                        { label: "Text", name: "text", widget: "string" },
+                                        { label: "URL", name: "url", widget: "string" }
+                                    ]
+                                },
+                                {
+                                    label: "Disease Catalog Link",
+                                    name: "disease",
+                                    widget: "object",
+                                    fields: [
+                                        { label: "Text", name: "text", widget: "string" },
+                                        { label: "URL", name: "url", widget: "string" }
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                }
                 - { label: "Body", name: "body", widget: "markdown" }
                 - {
                       label: "Main",


### PR DESCRIPTION
Problem
=======
Advances #163 

Solution
========
Earlier today I opened a PR for this feature that grabbed all the data in the normal-catalog query and sent it down as props.

Query lines and other code really started to crowd the normal-catalog component, I think it might be better organization to have a component query for the about section.

The only other difference is that I have removed the Corriell button. I'm adding it back, with the other buttons in another PR.

Draft PR showing completed section with buttons here:
https://github.com/allen-cell-animated/cell-catalog/pull/228

Add text and links for About section and table header to config/markdown.

* New feature (non-breaking change which adds functionality)

<img width="1469" alt="Screenshot 2025-06-04 at 4 58 04 PM" src="https://github.com/user-attachments/assets/9ca01f4d-4e26-4be3-bec0-7ae042bfea2b" />
