### PR TITLE
remove brackets from formatted gene location text

### DIFF
--- a/src/components/SubPage/EditingDesign.tsx
+++ b/src/components/SubPage/EditingDesign.tsx
@@ -14,9 +14,10 @@ const formatTextWithGeneLocations = (text: string, className: string) => {
     const parts = text.split(/(\[.*?\])/);
     return parts.map((part, index) => {
         if (part.startsWith("[") && part.endsWith("]")) {
+            const bracketsRemoved = part.slice(1, -1);
             return (
                 <span key={index} className={className}>
-                    {part}
+                    {bracketsRemoved}
                 </span>
             );
         }


### PR DESCRIPTION
Problem
=======
Jacqueline requested that gene editing sites indicated with brackets have the brackets removed in the resulting text.

Solution
========

<img width="1395" alt="Screenshot 2025-06-04 at 5 53 02 PM" src="https://github.com/user-attachments/assets/8ef52193-7043-4870-be97-4108ff627170" />
