### PR TITLE
rework footer data and styling

### DIFF
--- a/src/components/CellLineTable/index.tsx
+++ b/src/components/CellLineTable/index.tsx
@@ -2,7 +2,6 @@ import React, { useState } from "react";
 import { Table, Tag, Flex } from "antd";
 import { navigate } from "gatsby";
 
-import { HTMLContent } from "../shared/Content";
 import { CellLineStatus } from "../../component-queries/types";
 
 import useWindowWidth from "../../hooks/useWindowWidth";
@@ -14,7 +13,6 @@ const {
     tableTitle,
     container,
     comingSoon,
-    footer,
     hoveredRow,
     dataComplete,
 } = require("../../style/table.module.css");
@@ -31,7 +29,6 @@ interface CellLineTableProps {
 const CellLineTable = ({
     tableName,
     cellLines,
-    footerContents,
     released,
     columns,
     mobileConfig,
@@ -116,9 +113,6 @@ const CellLineTable = ({
                 showSorterTooltip={false}
                 sortDirections={["ascend", "descend", "ascend"]}
             />
-            <div className={footer}>
-                <HTMLContent content={footerContents} />
-            </div>
         </>
     );
 };

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,44 +1,77 @@
 import React from "react";
 import { HTMLContent } from "./shared/Content";
-
+import { Divider } from "antd";
 const {
     container,
+    collaboratorsSection,
     contributor,
     institution,
+    generation,
 } = require("../style/footer.module.css");
 
 interface FooterProps {
+    generationText?: string;
     acknowledgementsBlock: {
         intro: string;
+        collaborators?: { name: string; institution: string }[];
+        contributor_text?: string;
         contributors: { name: string; institution: string }[];
-        outro: string;
     };
     fundingText: string;
 }
 
 const Footer: React.FC<FooterProps> = ({
+    generationText,
     acknowledgementsBlock,
     fundingText,
 }) => {
-    const { intro, contributors, outro } = acknowledgementsBlock;
+    const { intro, collaborators, contributor_text, contributors } =
+        acknowledgementsBlock;
+
     return (
-        <div className={container}>
-            <div>
-                <h3>Acknowledgements</h3>
-                <p> {intro} </p>
-                {contributors.map((p, i) => (
-                    <div key={i}>
-                        <span className={contributor}>{p.name}</span>,{" "}
-                        <span className={institution}>{p.institution}</span>
-                    </div>
-                ))}
-                <p> {outro} </p>
+        <>
+            {generationText && (
+                <div>
+                    <HTMLContent
+                        className={generation}
+                        content={generationText}
+                    />
+                    <Divider />
+                </div>
+            )}
+            <div className={container}>
+                <div>
+                    <h3>Acknowledgements</h3>
+                    <p>{intro}</p>
+                    {collaborators && (
+                        <div className={collaboratorsSection}>
+                            {collaborators.map((p, i) => (
+                                <div key={`collaborator-${i}`}>
+                                    <span className={contributor}>
+                                        {p.name}
+                                    </span>
+                                    ,{" "}
+                                    <span className={institution}>
+                                        {p.institution}
+                                    </span>
+                                </div>
+                            ))}
+                        </div>
+                    )}
+                    {contributor_text && <p>{contributor_text}</p>}
+                    {contributors.map((p, i) => (
+                        <div key={`contributor-${i}`}>
+                            <span className={contributor}>{p.name}</span>,{" "}
+                            <span className={institution}>{p.institution}</span>
+                        </div>
+                    ))}
+                </div>
+                <div>
+                    <h3>Funding</h3>
+                    <HTMLContent content={fundingText} />
+                </div>
             </div>
-            <div>
-                <h3>Funding</h3>
-                <HTMLContent content={fundingText} />
-            </div>
-        </div>
+        </>
     );
 };
 

--- a/src/pages/disease-catalog/index.md
+++ b/src/pages/disease-catalog/index.md
@@ -14,6 +14,45 @@ footer_text: All cell lines were originally generated using the WTC-11 hiPS cell
   coverage) for the WTC-11 line
   on the [Genomics](https://www.allencell.org/genomics.html) page. The donor of
   the WTC line has consented to the sharing of this data.
+acknowledgements_block:
+    intro: >
+      These cell lines were generated at the Allen Institute for Cell Science and released to a group of collaborators to perform preliminary studies. We would like to thank the following:
+    collaborators:
+        - name: Daniel Berstein, MD
+          institution: Stanford University
+        - name: Abigail Buchwalter, PhD
+          institution: University of California, San Francisco
+        - name: Francis Collins, MD, PhD
+          institution: NIH
+        - name: Michael Erdos, PhD
+          institution: NIH
+        - name: Soah Lee, PhD
+          institution: Sungkyunkwan University
+        - name: David Mack, PhD
+          institution: University of Washington
+        - name: Beth Pruitt, PhD
+          institution: University of California, Santa Barbara
+        - name: Mike Regnier, PhD
+          institution: University of Washington
+        - name: James Spudich, PhD
+          institution: Stanford University
+        - name: Sean Wu, MD, PhD
+          institution: Stanford School of Medicine
+        - name: Zhengmei Xiong, PhD
+          institution: NIH
+    contributor_text: >
+          The Allen Institute for Cell Science also acknowledges the following people for their expertise and support:
+    contributors:
+        - name: Bruce R. Conklin
+          institution: Gladstone Institute and University of California, San Francisco
+        - name: Charles E. Murray
+          institution: University of Washington
+        - name: William C. Skarnes
+          institution: Wellcome Trust Sanger Institute
+        - name: David Drubin
+          institution: University of California, Berkley
+funding_text: >
+  We wish to thank Allen Institute founders, Jody Allen & Paul G. Allen, for their vision, encouragement, and support.
 ---
 The Disease Collection Cell Catalog is a growing compilation of cell lines that carry mutations in genes known to cause disease. These cell lines were created by introducing a point mutation in one of the fluorescently tagged WTC-11 clonal lines from the [Allen Cell Collection](https://www.allencell.org/cell-catalog.html).
 

--- a/src/style/colors.sass
+++ b/src/style/colors.sass
@@ -11,6 +11,7 @@
     --RED: #FF0000;
     --BLUE_70: #204A6C;
     --GRAY_60: #323233;
+    --GRAY_40: #7C7D7F;
 
     --ALLEN_LIGHT_10: #DFE5EA;
     --ALLEN_LIGHT_30: #9FB1C0;
@@ -23,7 +24,7 @@
     --link-color: #0094FF;
     --small-table-border-color: var(--RAIN_SHADOW);
     --main-card-header-color: var(--primary-color);
-    --footer-text: var(--BLUE_70);
+    --footer-text: var(--GRAY_40);
     --tooltip-background: var(--GRAY_60);
 }
 

--- a/src/style/footer.module.css
+++ b/src/style/footer.module.css
@@ -1,11 +1,28 @@
 .container {
-    color: var(--footer-text);
     display: flex;
     flex-direction: column;
     font-size: 16px;
     font-weight: 400;
     gap: 24px;
     margin-top: 25px;
+}
+
+.container,
+.container h3 {
+    color: var(--footer-text);
+}
+
+.generation {
+    margin-bottom: 40px;
+    color: var(--footer-text);
+}
+
+.generation a {
+    color: var(--link-color);
+}
+
+.collaborators-section {
+    margin-bottom: 24px;
 }
 
 .container p {

--- a/src/templates/disease-catalog.tsx
+++ b/src/templates/disease-catalog.tsx
@@ -6,6 +6,7 @@ import Diseases from "../component-queries/Diseases";
 import Content, { HTMLContent } from "../components/shared/Content";
 import { GatsbyImage, getImage } from "gatsby-plugin-image";
 import { FileNode } from "gatsby-plugin-image/dist/src/components/hooks";
+import Footer from "../components/Footer";
 
 const {
     coriellCard,
@@ -20,6 +21,13 @@ interface DiseaseCatalogTemplateProps {
     content: string;
     contentComponent?: JSX.ElementType;
     footerText: string;
+    fundingText: string;
+    acknowledgementsBlock: {
+        intro: string;
+        collaborators: { name: string; institution: string }[];
+        contributor_text: string;
+        contributors: { name: string; institution: string }[];
+    };
     main: {
         heading: string;
         description: string;
@@ -34,6 +42,8 @@ export const DiseaseCatalogTemplate = ({
     content,
     contentComponent,
     footerText,
+    fundingText,
+    acknowledgementsBlock,
     main,
     coriellImage,
     coriellLink,
@@ -73,7 +83,11 @@ export const DiseaseCatalogTemplate = ({
                 />
             </Card>
             <Diseases />
-            <HTMLContent className="footer" content={footerText} />
+            <Footer
+                generationText={footerText}
+                acknowledgementsBlock={acknowledgementsBlock}
+                fundingText={fundingText}
+            />
         </section>
     );
 };
@@ -86,6 +100,15 @@ interface QueryResult {
                 title: string;
                 footer_text: {
                     html: string;
+                };
+                funding_text: {
+                    html: string;
+                };
+                acknowledgements_block: {
+                    intro: string;
+                    collaborators: { name: string; institution: string }[];
+                    contributor_text: string;
+                    contributors: { name: string; institution: string }[];
                 };
                 main: {
                     heading: string;
@@ -108,6 +131,8 @@ const DiseaseCatalog = ({ data }: QueryResult) => {
                 title={post.frontmatter.title}
                 content={post.html}
                 footerText={post.frontmatter.footer_text.html}
+                fundingText={post.frontmatter.funding_text.html}
+                acknowledgementsBlock={post.frontmatter.acknowledgements_block}
                 main={post.frontmatter.main}
                 coriellImage={post.frontmatter.coriell_image}
                 coriellLink={post.frontmatter.coriell_link}
@@ -126,6 +151,21 @@ export const aboutPageQuery = graphql`
                 title
                 footer_text {
                     html
+                }
+                funding_text {
+                    html
+                }
+                acknowledgements_block {
+                    intro
+                    collaborators {
+                        name
+                        institution
+                    }
+                    contributor_text
+                    contributors {
+                        name
+                        institution
+                    }
                 }
                 main {
                     heading

--- a/src/templates/normal-catalog.tsx
+++ b/src/templates/normal-catalog.tsx
@@ -11,8 +11,6 @@ import NormalCellLines from "../component-queries/NormalCellLines";
 const {
     container,
     coriellCard,
-    banner,
-    bannerContent,
     header,
     mainHeading,
     coriellWrapper,
@@ -88,9 +86,6 @@ interface QueryResult {
             html: string;
             frontmatter: {
                 title: string;
-                footer_text: {
-                    html: string;
-                };
                 funding_text: {
                     html: string;
                 };

--- a/static/admin/config.yml
+++ b/static/admin/config.yml
@@ -740,7 +740,41 @@ collections:
                       name: "footer_text",
                       widget: "markdown",
                   }
-
+                - {
+                    label: "Acknowledgements Block",
+                    name: "acknowledgements_block",
+                    widget: "object",
+                    fields:
+                        [
+                            { label: "Intro", name: "intro", widget: "string" },
+                            {
+                                label: "Contributors",
+                                name: "contributors",
+                                widget: "list",
+                                required: false,
+                                collapsed: true,
+                                fields:
+                                    [
+                                        {
+                                            label: "Name",
+                                            name: "name",
+                                            widget: "string",
+                                        },
+                                        {
+                                            label: "Institution",
+                                            name: "institution",
+                                            widget: "string",
+                                        },
+                                    ],
+                            },
+                            { label: "Outro", name: "outro", widget: "string" },
+                        ],
+                }
+                - {
+                    label: "Funding",
+                    name: "funding_text",
+                    widget: "markdown",
+                }
           - file: "src/pages/normal-catalog/index.md"
             label: "Cell Line Catalog"
             name: "normal-catalog"


### PR DESCRIPTION
Problem
=======
Closes #199 

Solution
========
New design: https://www.figma.com/design/kMIJN6BoOkXIhnVUruIHNT/Website-allencell.org?node-id=2303-7115&t=RR0hxKNaHKmB9kBj-4
Rework the data and rending for the disease catalog footer.

There are now a number of fields only rendered for the normal catalog (generation, collaborators). If it seems unreadable or messy I can split into separate Footer components for disease and normal catalogs.

![Screenshot 2025-06-05 at 12 55 03 PM](https://github.com/user-attachments/assets/a0219e06-0341-4fa1-88a0-46438723cddd)

![Screenshot 2025-06-05 at 12 55 16 PM](https://github.com/user-attachments/assets/3ca80949-22be-419d-8513-3a41d5f135d3)
