### PR TITLE
normalize thumbnails

### DIFF
--- a/src/style/table.module.css
+++ b/src/style/table.module.css
@@ -13,6 +13,13 @@
     position: absolute;
     top: 0;
     left: 0;
+    width: 100%;
+    height: 100%;
+}
+
+.thumbnail-container :global(.gatsby-image-wrapper) {
+    width: 100%;
+    height: 100%;
 }
 
 .id-header {
@@ -186,6 +193,15 @@
 
 .container.coming-soon .clones {
     border-right: 1px solid transparent;
+}
+
+.container.coming-soon .thumbnail-container {
+    display: none;
+}
+
+.container.coming-soon .id-header {
+    position: static;
+    text-align: left;
 }
 
 .container


### PR DESCRIPTION
Problem
=======
What is the problem this work solves, including
closes #226

Solution
========
What I/we did to solve this problem
- all the thumbnails now cover the whole cell
- thumbnails are disabled in the coming soon table

## Type of change
Please delete options that are not relevant.

* Bug fix (non-breaking change which fixes an issue)

Screenshots (optional):
-----------------------
<img width="885" alt="Screenshot 2025-06-05 at 4 26 41 PM" src="https://github.com/user-attachments/assets/1d7d7e9a-1ee9-4f2a-9aa7-ec8e397d2395" />

<img width="969" alt="Screenshot 2025-06-05 at 4 26 55 PM" src="https://github.com/user-attachments/assets/ee944b94-706a-4cf9-928a-66b99829d2f7" />
