### PR TITLE
fix: sort protein and structure arrays

### DIFF
--- a/src/components/CellLineTable/NormalTableColumns.tsx
+++ b/src/components/CellLineTable/NormalTableColumns.tsx
@@ -94,7 +94,10 @@ export const getNormalTableColumns = (
                 <MultiLineTableCell entries={proteins} />
             ),
             sorter: (a: any, b: any) =>
-                caseInsensitiveStringCompare(a.protein, b.protein),
+                caseInsensitiveStringCompare(
+                    (a.protein ?? []).join("|"),
+                    (b.protein ?? []).join("|")
+                ),
         },
         {
             title: "Gene Symbol & Name",
@@ -146,7 +149,10 @@ export const getNormalTableColumns = (
                 <MultiLineTableCell entries={structures} />
             ),
             sorter: (a: any, b: any) =>
-                caseInsensitiveStringCompare(a.structure, b.structure),
+                caseInsensitiveStringCompare(
+                    (a.structure ?? []).join("|"),
+                    (b.structure ?? []).join("|")
+                ),
         },
         {
             title: "Fluorescent Tag",


### PR DESCRIPTION
Problem
=======
What is the problem this work solves, including
closes #241

Solution
========
What I/we did to solve this problem
- fixed sorting issues on `protein` and `structure` column on `main`

sorting should be working on all columns in the cell line table now

## Type of change
Please delete options that are not relevant.

* Bug fix (non-breaking change which fixes an issue)
