### PR TITLE
Quick patch: render tagged alleles with MultiLineTableCell component

### DIFF
--- a/src/components/CellLineTable/NormalTableColumns.tsx
+++ b/src/components/CellLineTable/NormalTableColumns.tsx
@@ -128,9 +128,9 @@ export const getNormalTableColumns = (
             dataIndex: "alleleCount",
             responsive: mdBreakpoint,
             sortIcon: sortIcon,
-            render: (alleleCount: string[]) => {
-                return alleleCount?.join(" / ");
-            },
+            render: (alleleCount: string[]) => (
+                <MultiLineTableCell entries={alleleCount} />
+            ),
             sorter: (a: any, b: any) =>
                 caseInsensitiveStringCompare(
                     (a.alleleCount ?? []).join("|"),


### PR DESCRIPTION
Problem
=======
What is the problem this work solves, including
tagged allele can also contain multiple lines

Solution
========
What I/we did to solve this problem
use `MultiLineTableCell` component to render tagged alleles column 

## Type of change
* New feature (non-breaking change which adds functionality)


Steps to Verify:
----------------
<img width="792" alt="Screenshot 2025-06-09 at 12 59 43 PM" src="https://github.com/user-attachments/assets/88ba725f-31c0-4b42-bf63-6670d1f72523" />
<img width="819" alt="Screenshot 2025-06-09 at 12 59 27 PM" src="https://github.com/user-attachments/assets/15d40b7c-ff62-43c8-ad32-ee6c96b77660" />

