### PR TITLE
Fix cert icon style

### DIFF
--- a/src/components/CellLineTable/SharedColumns.tsx
+++ b/src/components/CellLineTable/SharedColumns.tsx
@@ -17,6 +17,7 @@ const {
     actionColumn,
     actionButton,
     tubeIcon,
+    certIcon,
     idHeader,
     thumbnailContainer,
 } = require("../../style/table.module.css");
@@ -72,6 +73,7 @@ export const certificateOfAnalysisColumn = {
                 >
                     <Flex>
                         <Icon
+                            className={certIcon}
                             component={CertificateIcon}
                             style={{
                                 color: WHITE,

--- a/src/style/table.module.css
+++ b/src/style/table.module.css
@@ -96,6 +96,12 @@
     stroke: var(--WHITE);
 }
 
+.action-column:hover .action-button .cert-icon path,
+.action-column:hover .action-button .cert-icon line {
+    fill: var(--primary-color);
+    stroke: var(--WHITE);
+}
+
 .action-column:hover .plasmid-icon path {
     fill: var(--WHITE);
 }


### PR DESCRIPTION
Problem
=======
What is the problem this work solves, including
closes #246 

Solution
========
What I/we did to solve this problem
- add style for cert icon

before:
<img width="325" alt="Screenshot 2025-06-30 at 1 26 55 PM" src="https://github.com/user-attachments/assets/dee7afb9-14fa-4807-89a4-b58ec544c453" />


after:
<img width="324" alt="Screenshot 2025-06-30 at 1 22 41 PM" src="https://github.com/user-attachments/assets/adf71733-d41e-4c97-8852-46035c10f581" />

## Help needed
The cert icon is missing the inner triangle detail in the top-right corner, I tried modifying the stroke color in svg file, adding specific css rules for the svg and various fill/stroke combinations, none of them worked. Any experience with similar issues?

on design:
<img width="108" alt="Screenshot 2025-06-30 at 1 36 57 PM" src="https://github.com/user-attachments/assets/a196a363-d4d0-4ba6-b18e-dc6d494c30cc" />



## Type of change
Please delete options that are not relevant.

* Bug fix (non-breaking change which fixes an issue)


Steps to Verify:
----------------
1. Preview

