### PR TITLE
remove the current subheading for disease catalog

### DIFF
--- a/src/pages/disease-catalog/index.md
+++ b/src/pages/disease-catalog/index.md
@@ -6,7 +6,7 @@ main:
   description: Data for our lines will be added to this page in a user-friendly
     format later this year. In the meantime, access a large selection of QC and
     other data via the Certificate of Analysis associated with each line.
-  subheading: Updated User Experience Coming Soon!
+  subheading: ""
 coriell_image: /img/coriell.png
 coriell_link: https://www.coriell.org/1/AllenCellCollection
 footer_text: All cell lines were originally generated using the WTC-11 hiPS cell

--- a/src/templates/disease-catalog.tsx
+++ b/src/templates/disease-catalog.tsx
@@ -65,7 +65,7 @@ export const DiseaseCatalogTemplate = ({
             </Flex>
             <h2 className={mainHeading}>{main.heading}</h2>
             <Card className={banner} bordered={true}>
-                <h4>{main.subheading}</h4>
+                {main.subheading && <h4>{main.subheading}</h4>}
                 <PageContent
                     className={bannerContent}
                     content={main.description}

--- a/static/admin/config.yml
+++ b/static/admin/config.yml
@@ -719,6 +719,7 @@ collections:
                                   label: Subheading,
                                   name: subheading,
                                   widget: string,
+                                  required: false,
                               },
 
                               {


### PR DESCRIPTION
Problem
=======
What is the problem this work solves, including
close #197 

Solution
========
What I/we did to solve this problem
- removed the subheading content from the md file
- set the subheading field as optional in the data config file


## Type of change
Please delete options that are not relevant.

* New feature (non-breaking change which adds functionality)


Steps to Verify:
----------------
1. Check the Preview page
<img width="1699" alt="Screenshot 2025-06-30 at 2 17 15 PM" src="https://github.com/user-attachments/assets/c7d79804-6b16-4041-ae33-796505a786cf" />
