### PR TITLE
formatting script and gh action

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -1,0 +1,16 @@
+name: Prettier check
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+jobs:
+  prettier:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '18.x'
+      - run: npm ci      
+      - run: npm run format:check

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,8 @@
+node_modules
+.cache
+public/
+static/admin/*.bundle.*
+.DS_Store
+yarn-error.log
+.vscode
+.netlify

--- a/package.json
+++ b/package.json
@@ -49,8 +49,8 @@
     "build": "npm run clean && gatsby build",
     "develop": "npm run clean && gatsby develop",
     "serve": "gatsby serve",
-    "format": "prettier --trailing-comma es5 --no-semi --single-quote --write --tab-width 4 \"{gatsby-*.js,src/**/*.js}\"",
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "format": "prettier --write \"**/*.{js,jsx,ts,tsx,json,md,mdx,yml,yaml}\"",
+    "format:check":  "prettier --check \"**/*.{js,jsx,ts,tsx,json,md,mdx,yml,yaml}\"",
     "dev": "npx concurrently \"npx netlify-cms-proxy-server\" \"npm start -- --progress\""
   },
   "devDependencies": {

--- a/prettierrc.json
+++ b/prettierrc.json
@@ -1,0 +1,7 @@
+{
+    "semi": false,
+    "singleQuote": true,
+    "trailingComma": "es5",
+    "tabWidth": 4,
+    "endOfLine": "lf"
+}


### PR DESCRIPTION
Problem
=======
Advances #251

Solution
========
This addresses the first portion of work:
- defining prettier config and `write` and `check` scripts
- defines a github action to check PRs for prettier warnings/errors (doesn't make any changes or block merging)

The write script has not be run in this PR, as it will affect 200+ files, once this is approved we can run it no a branch and merge the changes, or alternately define a gh action, or use husky, to run the script automatically either before committing or when PRs are opened.

Is anyone opinionated on how the config should be set up?

* New feature (non-breaking change which adds functionality)
