### PR TITLE
create stylesheet for normal cell line subpage

### DIFF
--- a/src/style/cell-line.module.css
+++ b/src/style/cell-line.module.css
@@ -1,0 +1,11 @@
+.container {
+    border: 1px black solid;
+    display: flex;
+    justify-content: space-evenly;
+    padding: 6px;
+}
+
+.section {
+    border: 1px blue solid;
+    padding: 6px;
+}

--- a/src/templates/cell-line.tsx
+++ b/src/templates/cell-line.tsx
@@ -4,6 +4,8 @@ import Layout from "../components/Layout";
 import { GatsbyImage, getImage } from "gatsby-plugin-image";
 import { GeneticModification } from "../component-queries/types";
 
+const { container, section } = require("../style/cell-line.module.css");
+
 interface QueryResult {
     data: {
         markdownRemark: {
@@ -37,27 +39,32 @@ export const CellLineTemplate = ({
 }: CellLineProps) => {
     const image = getImage(thumbnail);
     return (
-        <section className="section">
-            <div className="container content">
-                <div className="columns">
-                    <div className="column is-10 is-offset-1">
-                        <h1 className="title is-size-2 has-text-weight-bold is-bold-light">
-                            AICS-{cellLineId}
-                        </h1>
-                        <p>Clone Number: {cloneNumber}</p>
-                        <p>Gene: {geneticModifications?.map(mod => mod.gene?.frontmatter?.symbol).join(" / ")}</p>
-                        <p>Tag: {geneticModifications?.map(mod => mod.tag_location).join(" / ")}</p>
-                        <p>Status: {status}</p>
-                        {image && (
-                            <GatsbyImage
-                                image={image}
-                                alt="Cell Line Thumbnail"
-                            />
-                        )}
-                    </div>
-                </div>
+        <div className={container}>
+            <div className={section}>
+                <h1>AICS-{cellLineId}</h1>
+                <p>Clone Number: {cloneNumber}</p>
+                <p>
+                    Gene:{" "}
+                    {geneticModifications
+                        ?.map((mod) => mod.gene?.frontmatter?.symbol)
+                        .join(" / ")}
+                </p>
+                <p>
+                    Tag:{" "}
+                    {geneticModifications
+                        ?.map((mod) => mod.tag_location)
+                        .join(" / ")}
+                </p>
+                <p>Status: {status}</p>
             </div>
-        </section>
+            <div className={section}>
+                <h1>Images</h1>
+                <p>Thumbnail:</p>
+                {image && (
+                    <GatsbyImage image={image} alt="Cell Line Thumbnail" />
+                )}
+            </div>
+        </div>
     );
 };
 
@@ -68,7 +75,9 @@ const CellLine = ({ data }: QueryResult) => {
             <CellLineTemplate
                 cellLineId={cellLine.frontmatter.cell_line_id}
                 cloneNumber={cellLine.frontmatter.clone_number}
-                geneticModifications={cellLine.frontmatter.genetic_modifications}
+                geneticModifications={
+                    cellLine.frontmatter.genetic_modifications
+                }
                 status={cellLine.frontmatter.status}
                 thumbnail={cellLine.frontmatter.thumbnail_image}
             />


### PR DESCRIPTION
Problem
=======
Advances #254 Closes #260

Solution
========
I added a stylesheet for the normal cell lines.

The styling rules are just initial placeholders to organize things as we add data and update the queries.

* New feature (non-breaking change which adds functionality)

<img width="881" height="280" alt="Screenshot 2025-07-14 at 1 34 22 PM" src="https://github.com/user-attachments/assets/f8899113-3256-43e1-908a-39ef10b76cef" />


