### PR TITLE
component for styling gene symbol tags

### DIFF
--- a/src/components/CellLineInfoCard/DiseaseCellLineInfoCard.tsx
+++ b/src/components/CellLineInfoCard/DiseaseCellLineInfoCard.tsx
@@ -6,6 +6,7 @@ import { CellLineInfoCardRequiredProps } from "./types";
 import { Divider } from "antd";
 import { PRIMARY_COLOR } from "../../style/theme";
 import CloneTable from "../CloneTable";
+import GeneSymbolTag from "../GeneSymbolTag";
 
 interface DiseaseCellLineInfoCardProps extends CellLineInfoCardRequiredProps {
     parentalLine: ParentLine;
@@ -29,7 +30,11 @@ export const DiseaseCellLineInfoCard: React.FC<DiseaseCellLineInfoCardProps> = (
 
     const infoRows = [
         { key: "1", label: "SNP", children: props.snp },
-        { key: "2", label: "Gene Symbol", children: props.geneSymbol },
+        {
+            key: "2",
+            label: "Gene Symbol",
+            children: <GeneSymbolTag symbol={props.geneSymbol}/>,
+        },
         { key: "3", label: "Gene Name", children: props.geneName },
         {
             key: "4",

--- a/src/components/CellLineInfoCard/NormalCellLineInfoCard.tsx
+++ b/src/components/CellLineInfoCard/NormalCellLineInfoCard.tsx
@@ -1,6 +1,8 @@
 import React from "react";
 import CellLineInfoCardBase from "./CellLineInfoCardBase";
 import { CellLineInfoCardRequiredProps } from "./types";
+import GeneSymbolTag from "../GeneSymbolTag";
+
 interface NormalCellLineInfoCardProps extends CellLineInfoCardRequiredProps {
     orderPlasmid: string;
     cloneNumber: number;
@@ -40,35 +42,36 @@ export const NormalCellLineInfoCard: React.FC<NormalCellLineInfoCardProps> = (
 
     // matching the data with catalog 1.0, the final version may change depending on the design
     // for now, showing only the first gene data if a line has multiple genes
-    const infoRows = [
-        { key: "1", label: "Clone Number", children: props.cloneNumber },
-        {
-            key: "2",
-            label: "Gene Symbol",
-            children: extractFieldsFromTaggedGene("symbol"),
-        },
-
-        {
-            key: "3",
-            label: "Gene Name",
-            children: extractFieldsFromTaggedGene("name"),
-        },
-        {
-            key: "4",
-            label: "Protein",
-            children: extractFieldsFromTaggedGene("protein"),
-        },
-        {
-            key: "5",
-            label: "Fluorescent Tag",
-            children: props.fluorescentTag.join(", "),
-        },
-        {
-            key: "6",
-            label: "Tagged Allele",
-            children: props.alleleCount.join(", "),
-        },
-    ];
+   const infoRows = [
+       { key: "1", label: "Clone Number", children: props.cloneNumber },
+       {
+           key: "2",
+           label: "Gene Symbol",
+           children: (
+               <GeneSymbolTag symbol={extractFieldsFromTaggedGene("symbol")} />
+           ),
+       },
+       {
+           key: "3",
+           label: "Gene Name",
+           children: extractFieldsFromTaggedGene("name"),
+       },
+       {
+           key: "4",
+           label: "Protein",
+           children: extractFieldsFromTaggedGene("protein"),
+       },
+       {
+           key: "5",
+           label: "Fluorescent Tag",
+           children: props.fluorescentTag.join(", "),
+       },
+       {
+           key: "6",
+           label: "Tagged Allele",
+           children: props.alleleCount.join(", "),
+       },
+   ];
 
     return (
         <CellLineInfoCardBase

--- a/src/components/GeneDisplay.tsx
+++ b/src/components/GeneDisplay.tsx
@@ -1,7 +1,8 @@
 import React from "react";
-import { Flex, Tag, Typography } from "antd";
+import { Flex, Typography } from "antd";
 import { UnpackedGene } from "../component-queries/types";
 import { getTooltipProps } from "./MultiLineTableCell";
+import GeneSymbolTag from "./GeneSymbolTag";
 
 interface GeneDisplayProps {
     gene: UnpackedGene;
@@ -13,9 +14,7 @@ const { Text } = Typography;
 const GeneDisplay: React.FC<GeneDisplayProps> = ({ gene }) => {
     return (
         <Flex wrap="nowrap" align="flex-end">
-            <Tag bordered={false} color="#DFE5EA">
-                {gene.symbol}
-            </Tag>
+            <GeneSymbolTag symbol={gene.symbol}/>
             <Text
                 className={truncatedText}
                 ellipsis={{

--- a/src/components/GeneSymbolTag.tsx
+++ b/src/components/GeneSymbolTag.tsx
@@ -1,0 +1,18 @@
+import React from "react";
+import { Tag } from "antd";
+
+interface GeneSymbolTagProps {
+    symbol: string;
+}
+
+const { tag } = require("../style/gene-symbol-tag.module.css");
+
+const GeneSymbolTag: React.FC<GeneSymbolTagProps> = ({ symbol }) => {
+    return (
+        <Tag className={tag} bordered={false}>
+            {symbol}
+        </Tag>
+    );
+};
+
+export default GeneSymbolTag;

--- a/src/style/gene-symbol-tag.module.css
+++ b/src/style/gene-symbol-tag.module.css
@@ -1,0 +1,5 @@
+.tag:global(.ant-tag) {
+    background-color: var(--ALLEN_LIGHT_10);
+    color: var(--SERIOUS_GRAY);
+    font-size: 14px;
+}

--- a/src/style/table.module.css
+++ b/src/style/table.module.css
@@ -166,11 +166,6 @@
     margin: 0;
 }
 
-.container :global(.ant-table-cell .ant-tag) {
-    color: var(--SERIOUS_GRAY);
-    font-size: 14px;
-}
-
 .container :global(.ant-table-cell .ant-btn) {
     background-color: var(--WHITE);
     font-weight: 600;


### PR DESCRIPTION
Problem
=======
We have designs from Travis for the Normal catalog info card.

In both disease and normal UX wants the gene symbol formatted as in the table.


Solution
========
Pulled out a small reusable for anywhere we need a styled gene symbol.

* New feature (non-breaking change which adds functionality)
