### PR TITLE
validate and flatten image data

### DIFF
--- a/src/component-queries/types.ts
+++ b/src/component-queries/types.ts
@@ -1,5 +1,5 @@
 import { IGatsbyImageData } from "gatsby-plugin-image";
-import { MediaFrontMatter, ValidatedImageData } from "../utils/mediaUtils";
+import { MediaFrontMatter, UnpackedImageData } from "../utils/mediaUtils";
 
 export interface Isoform {
     name: string;
@@ -107,12 +107,12 @@ export interface Sequence {
     type: string;
 }
 
-export interface SingleImageDiagram extends ValidatedImageData {
+export interface SingleImageDiagram extends UnpackedImageData {
     title: string;
 }
 
 export interface DiagramList {
-    images: ValidatedImageData[];
+    images: UnpackedImageData[];
     title: string;
 }
 

--- a/src/component-queries/types.ts
+++ b/src/component-queries/types.ts
@@ -1,5 +1,5 @@
 import { IGatsbyImageData } from "gatsby-plugin-image";
-import { RawImageData, MediaFrontMatter } from "../utils/mediaUtils";
+import { MediaFrontMatter, ValidatedImageData } from "../utils/mediaUtils";
 
 export interface Isoform {
     name: string;
@@ -107,12 +107,12 @@ export interface Sequence {
     type: string;
 }
 
-export interface SingleImageDiagram extends RawImageData {
+export interface SingleImageDiagram extends ValidatedImageData {
     title: string;
 }
 
 export interface DiagramList {
-    images: RawImageData[];
+    images: ValidatedImageData[];
     title: string;
 }
 

--- a/src/components/ImagesAndVideos.tsx
+++ b/src/components/ImagesAndVideos.tsx
@@ -3,7 +3,7 @@ import { Card, Flex, Image, Space } from "antd";
 import { ZoomOutOutlined, ZoomInOutlined } from "@ant-design/icons";
 import { GatsbyImage, getSrc } from "gatsby-plugin-image";
 import { formatCellLineId } from "../utils";
-import { RawVideoData, ImageOrVideo, isImage, ValidatedImageData } from "../utils/mediaUtils";
+import { RawVideoData, ImageOrVideo, isImage, UnpackedImageData } from "../utils/mediaUtils";
 import Thumbnail from "./Thumbnail";
 
 const {
@@ -25,7 +25,7 @@ const {
 } = require("../style/images-and-videos.module.css");
 
 interface ImagesAndVideosProps {
-    images: ValidatedImageData[];
+    images: UnpackedImageData[];
     cellLineId: number;
     videos: RawVideoData[];
     geneSymbol: string;

--- a/src/components/ImagesAndVideos.tsx
+++ b/src/components/ImagesAndVideos.tsx
@@ -1,9 +1,9 @@
 import React, { useState } from "react";
 import { Card, Flex, Image, Space } from "antd";
 import { ZoomOutOutlined, ZoomInOutlined } from "@ant-design/icons";
-import { getImage, GatsbyImage, getSrc } from "gatsby-plugin-image";
+import { GatsbyImage, getSrc } from "gatsby-plugin-image";
 import { formatCellLineId } from "../utils";
-import { RawImageData, RawVideoData, ImageOrVideo, isImage } from "../utils/mediaUtils";
+import { RawVideoData, ImageOrVideo, isImage, ValidatedImageData } from "../utils/mediaUtils";
 import Thumbnail from "./Thumbnail";
 
 const {
@@ -25,7 +25,7 @@ const {
 } = require("../style/images-and-videos.module.css");
 
 interface ImagesAndVideosProps {
-    images: RawImageData[];
+    images: ValidatedImageData[];
     cellLineId: number;
     videos: RawVideoData[];
     geneSymbol: string;
@@ -63,14 +63,11 @@ const ImagesAndVideos: React.FC<ImagesAndVideosProps> = ({
 
     const imageItems = mediaItems.filter(isImage);
     const allPreviewImages = imageItems
-        .map((item) => getImage(item.image))
-        .filter(Boolean)
-        .map((imgData, i) => {
-            if (imgData !== undefined)
+        .map((item, i) => {
                 return (
                     <Image
                         key={`preview-${i}`}
-                        src={getSrc(imgData)}
+                        src={getSrc(item.image)}
                         style={{ display: "none" }}
                         className={previewImage}
                     />
@@ -81,13 +78,10 @@ const ImagesAndVideos: React.FC<ImagesAndVideosProps> = ({
         const isSelected = selectedMedia === item;
 
         if (isImage(item)) {
-            const imageData = getImage(item.image);
-            if (!imageData) return null;
-
             return (
                 <Thumbnail
                     key={index}
-                    image={imageData}
+                    image={item.image}
                     isSelected={isSelected}
                     onClick={() => {
                         setSelectedMedia(item);
@@ -137,13 +131,14 @@ const ImagesAndVideos: React.FC<ImagesAndVideosProps> = ({
 
     const renderMedia = () => {
         if (isImage(selectedMedia)) {
-            const imageData = getImage(selectedMedia.image);
-            if (!imageData) return null;
-
             return (
                 <GatsbyImage
-                    className={showThumbnails ? primaryImageWithThumbnail : primaryImageOnly}
-                    image={imageData}
+                    className={
+                        showThumbnails
+                            ? primaryImageWithThumbnail
+                            : primaryImageOnly
+                    }
+                    image={selectedMedia.image}
                     alt="Cell line media"
                     imgStyle={{ objectFit: "contain" }}
                 />

--- a/src/components/SubPage/convert-data.ts
+++ b/src/components/SubPage/convert-data.ts
@@ -27,8 +27,6 @@ export const unpackDiagrams = (diagrams?: SingleImageDiagram[]): DiagramCardProp
             title: diagram.title,
             caption: diagram.caption,
             image: diagram.image
-                ? diagram.image.childImageSharp.gatsbyImageData
-                : undefined,
         };
     });
 };
@@ -49,7 +47,7 @@ export const unpackMultiImageDiagrams = (diagrams?: DiagramList[]): DiagramCardP
             result.push({
                 title: index === 0 ? diagram.title : "",
                 caption: imageObj.caption,
-                image: imageObj.image.childImageSharp.gatsbyImageData,
+                image: imageObj.image,
             });
         });
     });

--- a/src/utils/mediaUtils.ts
+++ b/src/utils/mediaUtils.ts
@@ -2,19 +2,14 @@ import { getImage, IGatsbyImageData } from "gatsby-plugin-image";
 
 export interface RawImageData {
   image: {
-    childImageSharp?: {
+    childImageSharp: {
       gatsbyImageData: IGatsbyImageData;
     };
   };
   caption: string;
 }
 
-interface RawImageWithData {
-  image: { childImageSharp: { gatsbyImageData: IGatsbyImageData } };
-  caption: string;
-};
-
-export interface ValidatedImageData {
+export interface UnpackedImageData {
   image: IGatsbyImageData;
   caption: string;
 }
@@ -29,35 +24,28 @@ export interface MediaFrontMatter {
   videos?: RawVideoData[];
 }
 
-export type ImageOrVideo = ValidatedImageData | RawVideoData;
-
-// type guard to ensure image data is defined
-export function hasGatsbyImageData(x: RawImageData): x is RawImageWithData {
-  return !!x.image.childImageSharp?.gatsbyImageData;
-}
+export type ImageOrVideo = UnpackedImageData | RawVideoData;
 
 // type guard to distinguish images and videos at runtime
-export function isImage(item: ImageOrVideo): item is ValidatedImageData {
+export function isImage(item: ImageOrVideo): item is UnpackedImageData {
   return "image" in item;
 }
 
 // flatten and validate image data
-export function toValidatedImageData(
+export function unpackImageData(
   x: RawImageData
-): ValidatedImageData | null {
-  return hasGatsbyImageData(x)
-    ? { image: x.image.childImageSharp.gatsbyImageData, caption: x.caption }
-    : null;
+): UnpackedImageData | null {
+  return { image: x.image.childImageSharp.gatsbyImageData, caption: x.caption };
 }
 
 export const hasMedia = (rawMedia?: MediaFrontMatter): boolean => {
   return Boolean(rawMedia?.images?.length || rawMedia?.videos?.length);
 };
 
-export const getImages = (raw?: MediaFrontMatter): ValidatedImageData[] => {
+export const getImages = (raw?: MediaFrontMatter): UnpackedImageData[] => {
   const media = (raw?.images ?? []);
-  return media.map(toValidatedImageData)
-    .filter((x): x is ValidatedImageData => x !== null);
+  return media.map(unpackImageData)
+    .filter((x): x is UnpackedImageData => x !== null);
 }
 
 export const getVideos = (rawMedia?: MediaFrontMatter): RawVideoData[] => {


### PR DESCRIPTION
One more round of suggestions!

Found two places where we needing to do an undefined check on `childImageSharp` and I figure why not just do a complete validation and unpacking in the media utils. This way all downstream consumers can just assume the image data is valid and present.