### PR TITLE
Fix on main: cell line subpage `return to cell catalog` button route 

### DIFF
--- a/src/templates/cell-line.tsx
+++ b/src/templates/cell-line.tsx
@@ -64,7 +64,7 @@ export const CellLineTemplate = ({
         <>
             <div className={container}>
                 <div className={leftCard}>
-                    <Link to="/normal-catalog">
+                    <Link to="/">
                         <DefaultButton>
                             <Arrow className={returnArrow} />
                             Return to Cell Catalog


### PR DESCRIPTION
Problem
=======
What is the problem this work solves, including
the `return to cell catalog` button leads to a 404

This bug is live in production, let's patch it quickly. Let me know if there are other missed spots when reviewing.

Solution
========
What I/we did to solve this problem
one line change: updated the route to point to the landing page


## Type of change
Please delete options that are not relevant.

* Bug fix (non-breaking change which fixes an issue)
