### PR TITLE
fix class name on image container

### DIFF
--- a/src/templates/cell-line.tsx
+++ b/src/templates/cell-line.tsx
@@ -15,7 +15,7 @@ import { hasMedia, getImages, getVideos } from "../utils/mediaUtils";
 
 const {
     container,
-    section,
+    imagesContainer,
     leftCard,
     returnArrow,
 } = require("../style/disease-cell-line.module.css");
@@ -84,7 +84,7 @@ export const CellLineTemplate = ({
                         alleleCount={alleleCount}
                     />
                 </div>
-                <div className={section}>
+                <div className={imagesContainer}>
                     {hasImagesOrVideos && (
                         <ImagesAndVideos
                             cellLineId={cellLineId}


### PR DESCRIPTION
Problem
=======
Images container was not aligned with its sibling on the normal lines. I thought I fixed this a while ago, so I don't know if I just fixed it on the disease lines, or if something overwrote it in a merge.



Solution
========
`section` class name no longer has rules associated with it, we should use `imagesContainer` to match the disease lines.


* Bug fix (non-breaking change which fixes an issue)
Before:
<img width="276" height="729" alt="Screenshot 2025-09-17 at 10 18 24 AM" src="https://github.com/user-attachments/assets/0ddddadd-f5d3-43fc-a580-9a4e61b223bf" />
After:

<img width="600" height="733" alt="Screenshot 2025-09-17 at 10 17 12 AM" src="https://github.com/user-attachments/assets/d1aff868-946f-45ae-8ff3-f5a9b3df90a0" />
