### PR TITLE
in disease catalog: return to new origin cell catalog

### DIFF
--- a/src/pages/disease-catalog/index.md
+++ b/src/pages/disease-catalog/index.md
@@ -54,6 +54,6 @@ acknowledgements_block:
 funding_text: >
   We wish to thank Allen Institute founders, Jody Allen & Paul G. Allen, for their vision, encouragement, and support.
 ---
-The Disease Collection Cell Catalog is a growing compilation of cell lines that carry mutations in genes known to cause disease. These cell lines were created by introducing a point mutation in one of the fluorescently tagged WTC-11 clonal lines from the [Allen Cell Collection](https://cell-catalog.allencell.org/).
+The Disease Collection Cell Catalog is a growing compilation of cell lines that carry mutations in genes known to cause disease. These cell lines were created by introducing a point mutation in one of the fluorescently tagged WTC-11 clonal lines from the [Allen Cell Collection](/).
 
 [Subscribe to our newsletter](https://www.alleninstitute.org/newsletter) to stay informed of frequently released new cell lines.

--- a/src/pages/index.md
+++ b/src/pages/index.md
@@ -13,7 +13,7 @@ about_block:
     text: Looking for a line with a disease mutation? Check out our Disease Cell Catalog.
     link:
       - text: Check out our Disease Cell Catalog
-        url: https://cell-catalog.allencell.org/disease-catalog/
+        url: /disease-catalog/
 table_header: "Allen Cell Collection Cell Lines"
 coriell_image: /img/coriell.png
 coriell_link: https://www.coriell.org/1/AllenCellCollection


### PR DESCRIPTION
Problem
=======
What is the problem this work solves, including
closes #331 

Solution
========
What I/we did to solve this problem
- update `Allen Cell Collection` link to point to the new original catalog
- no changes were made to user facing text per discussion

with @TravisKroeker 

## Type of change
Please delete options that are not relevant.

* New feature (non-breaking change which adds functionality)

Steps to Verify:
----------------
-[ preview here ](https://deploy-preview-363--cell-catalog.netlify.app/)
-[admin preview here](https://deploy-preview-363--cell-catalog.netlify.app/)

1. Go to preview disease catalog, click on `Allen Cell Collection`, confirm it opens up the new cell catalog page


