### PR TITLE
remove flash of copied text

### DIFF
--- a/src/components/CellLineInfoCard/CellLineInfoCardBase.tsx
+++ b/src/components/CellLineInfoCard/CellLineInfoCardBase.tsx
@@ -49,9 +49,7 @@ const CellLineInfoCardBase = ({
     infoRows,
     multiGene,
 }: CellLineInfoCardBaseProps) => {
-    const defaultToolTipText = "";
-    const [shareTooltipText, setShareTooltipText] =
-        useState(defaultToolTipText);
+    const [showToolTip, setShowToolTip] = useState(false);
 
     const getDefaultButton = (label: string, href: string) => (
         <DefaultButton key={href} href={href} target="_blank" rel="noreferrer">
@@ -109,16 +107,14 @@ const CellLineInfoCardBase = ({
             <Tooltip
                 title={"Cell line link copied to clipboard!"}
                 placement="bottom"
-                open={shareTooltipText !== defaultToolTipText}
+                open={showToolTip}
             >
                 <DarkThemeGhostButton
                     onClick={() => {
                         navigator.clipboard.writeText(href).then(() => {
-                            setShareTooltipText(
-                                "Cell line link copied to clipboard!",
-                            );
+                            setShowToolTip(true);
                             setTimeout(() => {
-                                setShareTooltipText(defaultToolTipText);
+                                setShowToolTip(false);
                             }, 1500);
                         });
                     }}


### PR DESCRIPTION
Problem
=======
there were two different tool tip texts and sometimes the instruction text flashed after you copied the url

Solution
========
made it match the prototype: no instruction tooltip, and just a success tooltip 

## Type of change
Please delete options that are not relevant.

* Bug fix (non-breaking change which fixes an issue)



Steps to Verify:
----------------
- [ ] add link to preview here 
- [ ] add link to admin preview here (and verify it loads)  

