### PR TITLE
to save new content this needs to be able to be empty

### DIFF
--- a/static/admin/config.yml
+++ b/static/admin/config.yml
@@ -1072,6 +1072,7 @@ collections:
                                   label: "Description",
                                   name: "description",
                                   widget: "markdown",
+                                  required: false,
                               },
                           ],
                   }


### PR DESCRIPTION
Problem
=======
you can't save new content for the disease catalog without a `main.description`

Solution
========
made it non required 


## Type of change
Please delete options that are not relevant.

* Bug fix (non-breaking change which fixes an issue)

[preview](https://deploy-preview-392--cell-catalog.netlify.app)