### PR TITLE
add margins to plasmid icon

### DIFF
--- a/src/style/navbarDropdown.module.css
+++ b/src/style/navbarDropdown.module.css
@@ -76,6 +76,11 @@
     margin-right: 12px;
 }
 
+.plasmid-icon :global(.plasmid-icon) {
+    margin-left: 2px;
+    margin-right: 2px;
+}
+
 .tube-icon :global(.tube-icon) {
     color: transparent;
 }


### PR DESCRIPTION
Problem
=======
Closes #395 

Solution
========
Just added some margins so the plasmid icon is the same size as the tube icon.

<img width="363" height="192" alt="Screenshot 2025-12-22 at 11 13 26 AM" src="https://github.com/user-attachments/assets/9da969e4-f52f-48f3-b571-e6bad9ee3156" />

