### PR TITLE
fix banner background for ios

### DIFF
--- a/src/style/banner.module.css
+++ b/src/style/banner.module.css
@@ -42,6 +42,7 @@
     .container {
         height: auto;
         padding: 0;
+        background-attachment: scroll;
     }
     .banner-container {
         padding: 100px 25px 50px;


### PR DESCRIPTION
Problem
=======
the banner background image displays blurry and zoomed-in on IOS, while Android shows it clearly

Solution
========
What I/we did to solve this problem
- added `background-attachment: scroll`


## Type of change
Please delete options that are not relevant.

* Bug fix (non-breaking change which fixes an issue)


Steps to Verify:
----------------
- scan the QR code to preview with your mobile devices
- [preview here](https://deploy-preview-418--cell-catalog.netlify.app/)
- [admin preview here](https://deploy-preview-418--cell-catalog.netlify.app/admin)

Screenshots (optional):
-----------------------
Show-n-tell images/animations here
before

<img src="https://github.com/user-attachments/assets/5007a874-2a24-49c9-a6d7-76172db390b2" width="300" />
<img src="https://github.com/user-attachments/assets/535b5ec9-0b22-4e99-b07f-e2f3abd289bf" width="300" />

after

<img src="https://github.com/user-attachments/assets/c77ae738-3c53-4fcd-95a5-747164662b5d" width="300" />
<img src="https://github.com/user-attachments/assets/e8f97a59-5fbc-42e7-8c14-d9e136f35ec8" width="300" />