### PR TITLE
Fix/icons

### DIFF
--- a/src/style/modal.module.css
+++ b/src/style/modal.module.css
@@ -70,7 +70,12 @@
     line-height: 33px;
 }
 
+.button-icon path {
+    fill: none;
+}
+
 .action-button:hover path {
+    fill: none;
     stroke: var(--WHITE);
 }
 

--- a/src/style/table.module.css
+++ b/src/style/table.module.css
@@ -146,6 +146,11 @@
     fill: var(--WHITE);
 }
 
+.cert-icon path,
+.cert-icon line {
+    fill: none;
+}
+
 .action-button.disabled :global(.tube-icon) line,
 .action-button.disabled :global(.tube-icon) path,
 .action-button.disabled .cert-icon path,


### PR DESCRIPTION
Problem
=======
What is the problem this work solves, including
my guess is that sometime after #325, an SVGO dependency update or a related svg change started applying `fill: currentColor` as an inline style on `<svg>`.
Which made some icons look off:

<img width="520" height="58" alt="Screenshot 2026-03-25 at 11 58 35 AM" src="https://github.com/user-attachments/assets/8119fa07-5623-425b-8afc-9ecd67ce3879" />
<img width="515" height="55" alt="Screenshot 2026-03-25 at 11 58 42 AM" src="https://github.com/user-attachments/assets/ee971856-dd76-4a7a-9aa9-4344aa862c7f" />
<img width="192" height="100" alt="Screenshot 2026-03-25 at 11 58 52 AM" src="https://github.com/user-attachments/assets/b15db4a0-7bb9-434d-ac21-1c9b45ee62f2" />
<img width="160" height="80" alt="Screenshot 2026-03-25 at 11 58 59 AM" src="https://github.com/user-attachments/assets/872138ba-c549-477e-a38a-3c2793710d87" />

Solution
========
What I/we did to solve this problem
- added `fill: none` to button icons and the cert icon in modal and table modules 


## Type of change
Please delete options that are not relevant.

* Bug fix (non-breaking change which fixes an issue)


Steps to Verify:
----------------
- [x] add link to [preview here](https://deploy-preview-427--cell-catalog.netlify.app/) 
- go to the preview site, hover over icons across pages, especially in disease table and parental line modal. They should render and behave as expected 

