### PR TITLE
add cloudinary image upload support 

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -59,6 +59,9 @@ exports.createSchemaCustomization = ({ actions, schema }) => {
             image: File @fileByRelativePath
             caption: String
             }
+            type ImagesAndVideos {
+            images: [ImgWithCaption]
+            }
             type Diagram {
             title: String
             images: [ImgWithCaption]
@@ -97,6 +100,7 @@ exports.createSchemaCustomization = ({ actions, schema }) => {
                 parental_line: MarkdownRemark @link(by: "frontmatter.cell_line_id")
                 funding_text:  String @md
                 footer_text: String @md
+                images_and_videos: ImagesAndVideos
                 genomic_characterization: MarkdownRemarkFrontmatterGenomic_characterization
                 stem_cell_characteristics: StemCellCharacteristics
                 catalogs: [NavBarDropdownItem]
@@ -125,8 +129,6 @@ exports.createResolvers = ({ createResolvers }) => {
     createResolvers({
         ImgWithCaption: imageUrlResolver,
         RnaSeqRow: imageUrlResolver,
-        // Gatsby-inferred types for image lists not covered by ImgWithCaption
-        MarkdownRemarkFrontmatterImages_and_videosImages: imageUrlResolver,
         MarkdownRemarkFrontmatterEditing_designDiagramsImages: imageUrlResolver,
         Diagram: imageUrlResolver,
     });

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -48,6 +48,12 @@ exports.createSchemaCustomization = ({ actions, schema }) => {
             options: [NavBarDropdownItem]
             }
 
+            type MarkdownRemarkFrontmatterHeader {
+            title: String
+            subtitle: String
+            background: File @fileByRelativePath
+            }
+
             `,
         `type GeneticModification {
                 gene: MarkdownRemark @link(by: "frontmatter.geneId", from: "gene")
@@ -131,6 +137,16 @@ exports.createResolvers = ({ createResolvers }) => {
         RnaSeqRow: imageUrlResolver,
         MarkdownRemarkFrontmatterEditing_designDiagramsImages: imageUrlResolver,
         Diagram: imageUrlResolver,
+        MarkdownRemarkFrontmatterHeader: {
+            background_url: {
+                type: "String",
+                resolve: (source) => {
+                    const bg = source.background;
+                    if (typeof bg === "string") return bg;
+                    return null;
+                },
+            },
+        },
     });
 };
 

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -108,6 +108,30 @@ exports.createSchemaCustomization = ({ actions, schema }) => {
     createTypes(typeDefs);
 };
 
+// Expose the raw image string as `image_url` for Cloudinary URL support.
+// The existing `image: File @fileByRelativePath` returns null for URLs,
+// so we need this field to pass through Cloudinary URLs to the frontend.
+exports.createResolvers = ({ createResolvers }) => {
+    const imageUrlResolver = {
+        image_url: {
+            type: "String",
+            resolve: (source) => {
+                const img = source.image;
+                if (typeof img === "string") return img;
+                return null;
+            },
+        },
+    };
+    createResolvers({
+        ImgWithCaption: imageUrlResolver,
+        RnaSeqRow: imageUrlResolver,
+        // Gatsby-inferred types for image lists not covered by ImgWithCaption
+        MarkdownRemarkFrontmatterImages_and_videosImages: imageUrlResolver,
+        MarkdownRemarkFrontmatterEditing_designDiagramsImages: imageUrlResolver,
+        Diagram: imageUrlResolver,
+    });
+};
+
 exports.createPages = ({ actions, graphql }) => {
     const { createPage } = actions;
 

--- a/src/cms/cloudinaryConfig.ts
+++ b/src/cms/cloudinaryConfig.ts
@@ -1,0 +1,6 @@
+// Cloudinary Upload Widget configuration
+// These are public, client-side values (not secrets).
+// The upload preset restricts what operations are allowed.
+export const CLOUDINARY_CLOUD_NAME = "dkg6lnogl";
+export const CLOUDINARY_UPLOAD_PRESET = "allen-cell";
+export const CLOUDINARY_API_KEY = "989839737788897";

--- a/src/cms/cms.tsx
+++ b/src/cms/cms.tsx
@@ -1,14 +1,27 @@
 import CMS from "decap-cms-app";
 import cloudinary from "decap-cms-media-library-cloudinary";
 import uploadcare from "decap-cms-media-library-uploadcare";
+import React from "react";
 
 import CellLinePreview from "./preview-templates/CellLinePreview";
 import DiseaseCatalogPreview from "./preview-templates/DiseaseCatalogPreview";
 import DiseaseCellLinePreview from "./preview-templates/DiseaseCellLinePreview";
 import GeneNamePreview from "./preview-templates/GeneNamePreview";
+import {
+    CloudinaryImagePreview,
+    CloudinaryImageWidget,
+} from "./widgets/CloudinaryImageWidget";
 
 CMS.registerMediaLibrary(uploadcare);
 CMS.registerMediaLibrary(cloudinary);
+
+// Decap CMS's registerWidget type doesn't include `entry` in control props,
+// but it passes it at runtime (Immutable.js Map). Cast required here.
+CMS.registerWidget(
+    "cloudinary-image",
+    CloudinaryImageWidget as unknown as React.FC,
+    CloudinaryImagePreview,
+);
 CMS.registerPreviewStyle(
     "https://cdnjs.cloudflare.com/ajax/libs/antd/4.4.3/antd.min.css",
 );

--- a/src/cms/widgets/CloudinaryImageWidget.tsx
+++ b/src/cms/widgets/CloudinaryImageWidget.tsx
@@ -1,0 +1,279 @@
+import React, { useCallback, useEffect, useRef } from "react";
+
+// Cloudinary configuration(temp)
+const CLOUD_NAME = "dkg6lnogl";
+const UPLOAD_PRESET = "allen-cell";
+const API_KEY = "989839737788897";
+
+// Decap CMS passes Immutable.js Maps — type the minimal surface we use
+interface ImmutableMap {
+    get: (key: string) => unknown;
+}
+
+interface CloudinaryWidgetProps {
+    value?: string;
+    onChange: (value: string) => void;
+    entry: ImmutableMap;
+}
+
+type CloudinaryWidgetInstance = {
+    destroy: () => void;
+    open: () => void;
+};
+
+type CloudinaryUploadResult = {
+    event: string;
+    info: { secure_url: string };
+};
+
+type CloudinaryWindow = Window & {
+    cloudinary?: {
+        createUploadWidget: (
+            config: object,
+            callback: (
+                error: Error | null,
+                result: CloudinaryUploadResult,
+            ) => void,
+        ) => CloudinaryWidgetInstance;
+    };
+};
+
+// Load the Cloudinary Upload Widget script once
+let scriptLoaded = false;
+function loadCloudinaryScript(): Promise<void> {
+    if (scriptLoaded) return Promise.resolve();
+    return new Promise((resolve, reject) => {
+        const script = document.createElement("script");
+        script.src =
+            "https://upload-widget.cloudinary.com/latest/global/all.js";
+        script.onload = () => {
+            scriptLoaded = true;
+            resolve();
+        };
+        script.onerror = reject;
+        document.head.appendChild(script);
+    });
+}
+
+/**
+ * Derives the Cloudinary upload folder from the current CMS entry.
+ * Maps each collection's templateKey to a folder structure:
+ *   cell-line          → cell-lines/AICS-{id}-{clone}
+ *   disease-cell-line  → disease-cell-lines/AICS-{id}
+ *   normal-catalog     → pages/normal-catalog
+ *   disease-catalog    → pages/disease-catalog
+ *   (unknown)          → uploads
+ */
+function getFolderFromEntry(entry: ImmutableMap): string {
+    const data = entry?.get("data") as ImmutableMap | undefined;
+    if (!data) return "uploads";
+
+    const templateKey = data.get("templateKey") as string | undefined;
+    const cellLineId = data.get("cell_line_id");
+    const cloneNumber = data.get("clone_number");
+
+    switch (templateKey) {
+        case "cell-line":
+            if (cellLineId != null && cloneNumber != null) {
+                return `cell-lines/AICS-${cellLineId}-${cloneNumber}`;
+            }
+            return "cell-lines";
+        case "disease-cell-line":
+            if (cellLineId != null) {
+                return `disease-cell-lines/AICS-${cellLineId}`;
+            }
+            return "disease-cell-lines";
+        case "normal-catalog":
+            return "pages/normal-catalog";
+        case "disease-catalog":
+            return "pages/disease-catalog";
+        default:
+            return "uploads";
+    }
+}
+
+// Decap CMS passes `entry` to widget controls at runtime,
+// but the TypeScript types don't declare it (Immutable.js Map).
+// Cast needed at registration site (cms.tsx) for the same reason.
+const CloudinaryImageWidget: React.FC<CloudinaryWidgetProps> = ({
+    entry,
+    onChange,
+    value,
+}) => {
+    const widgetRef = useRef<CloudinaryWidgetInstance | null>(null);
+
+    const openUploader = useCallback(async () => {
+        await loadCloudinaryScript();
+
+        const folder = getFolderFromEntry(entry);
+        const cloudinary = (window as CloudinaryWindow).cloudinary;
+
+        if (!cloudinary) {
+            console.error("Cloudinary upload widget not loaded");
+            return;
+        }
+
+        // Close any existing widget
+        if (widgetRef.current) {
+            widgetRef.current.destroy();
+        }
+
+        widgetRef.current = cloudinary.createUploadWidget(
+            {
+                cloudName: CLOUD_NAME,
+                uploadPreset: UPLOAD_PRESET,
+                apiKey: API_KEY,
+                folder: folder,
+                sources: ["local", "url", "camera"],
+                multiple: false,
+                resourceType: "image",
+                clientAllowedFormats: [
+                    "jpg",
+                    "jpeg",
+                    "png",
+                    "gif",
+                    "webp",
+                    "svg",
+                    "tiff",
+                ],
+                showPoweredBy: false,
+                styles: {
+                    palette: {
+                        window: "#FFFFFF",
+                        windowBorder: "#607E96",
+                        tabIcon: "#607E96",
+                        menuIcons: "#5A616A",
+                        textDark: "#000000",
+                        textLight: "#FFFFFF",
+                        link: "#607E96",
+                        action: "#339933",
+                        inactiveTabIcon: "#B3B3B3",
+                        error: "#F44235",
+                        inProgress: "#607E96",
+                        complete: "#339933",
+                        sourceBg: "#F4F4F5",
+                    },
+                },
+            },
+            (error: Error | null, result: CloudinaryUploadResult) => {
+                if (error) {
+                    console.error("Cloudinary upload error:", error);
+                    return;
+                }
+                if (result.event === "success") {
+                    const url = result.info.secure_url;
+                    onChange(url);
+                }
+            },
+        );
+
+        widgetRef.current.open();
+    }, [entry, onChange]);
+
+    // Cleanup on unmount
+    useEffect(() => {
+        return () => {
+            if (widgetRef.current) {
+                widgetRef.current.destroy();
+            }
+        };
+    }, []);
+
+    const folder = getFolderFromEntry(entry);
+    const hasImage = value && value.length > 0;
+
+    return (
+        <div
+            style={{
+                border: "1px solid #ddd",
+                borderRadius: "4px",
+                padding: "12px",
+            }}
+        >
+            {hasImage && (
+                <div style={{ marginBottom: "8px" }}>
+                    <img
+                        src={value}
+                        alt="Uploaded"
+                        style={{
+                            maxWidth: "100%",
+                            maxHeight: "200px",
+                            objectFit: "contain",
+                            borderRadius: "4px",
+                        }}
+                    />
+                    <div
+                        style={{
+                            fontSize: "11px",
+                            color: "#888",
+                            marginTop: "4px",
+                            wordBreak: "break-all",
+                        }}
+                    >
+                        {value}
+                    </div>
+                </div>
+            )}
+
+            <div style={{ display: "flex", gap: "8px", alignItems: "center" }}>
+                <button
+                    type="button"
+                    onClick={openUploader}
+                    style={{
+                        padding: "8px 16px",
+                        backgroundColor: "#607E96",
+                        color: "white",
+                        border: "none",
+                        borderRadius: "4px",
+                        cursor: "pointer",
+                        fontSize: "14px",
+                    }}
+                >
+                    {hasImage ? "Replace Image" : "Upload Image"}
+                </button>
+
+                {hasImage && (
+                    <button
+                        type="button"
+                        onClick={() => onChange("")}
+                        style={{
+                            padding: "8px 16px",
+                            backgroundColor: "#f5f5f5",
+                            color: "#333",
+                            border: "1px solid #ddd",
+                            borderRadius: "4px",
+                            cursor: "pointer",
+                            fontSize: "14px",
+                        }}
+                    >
+                        Remove
+                    </button>
+                )}
+            </div>
+
+            <div
+                style={{
+                    fontSize: "11px",
+                    color: "#888",
+                    marginTop: "8px",
+                }}
+            >
+                Uploads to: <strong>{folder}</strong>
+            </div>
+        </div>
+    );
+};
+
+// Preview component for the CMS preview pane
+const CloudinaryImagePreview: React.FC<{ value?: string }> = ({ value }) => {
+    if (!value) return null;
+    return (
+        <img
+            src={value}
+            alt="Preview"
+            style={{ maxWidth: "100%", maxHeight: "300px" }}
+        />
+    );
+};
+
+export { CloudinaryImageWidget, CloudinaryImagePreview };

--- a/src/cms/widgets/CloudinaryImageWidget.tsx
+++ b/src/cms/widgets/CloudinaryImageWidget.tsx
@@ -1,9 +1,10 @@
 import React, { useCallback, useEffect, useRef } from "react";
 
-// Cloudinary configuration(temp)
-const CLOUD_NAME = "dkg6lnogl";
-const UPLOAD_PRESET = "allen-cell";
-const API_KEY = "989839737788897";
+import {
+    CLOUDINARY_API_KEY,
+    CLOUDINARY_CLOUD_NAME,
+    CLOUDINARY_UPLOAD_PRESET,
+} from "../cloudinaryConfig";
 
 // Decap CMS passes Immutable.js Maps — type the minimal surface we use
 interface ImmutableMap {
@@ -120,9 +121,9 @@ const CloudinaryImageWidget: React.FC<CloudinaryWidgetProps> = ({
 
         widgetRef.current = cloudinary.createUploadWidget(
             {
-                cloudName: CLOUD_NAME,
-                uploadPreset: UPLOAD_PRESET,
-                apiKey: API_KEY,
+                cloudName: CLOUDINARY_CLOUD_NAME,
+                uploadPreset: CLOUDINARY_UPLOAD_PRESET,
+                apiKey: CLOUDINARY_API_KEY,
                 folder: folder,
                 sources: ["local", "url", "camera"],
                 multiple: false,

--- a/src/cms/widgets/CloudinaryImageWidget.tsx
+++ b/src/cms/widgets/CloudinaryImageWidget.tsx
@@ -204,11 +204,18 @@ const CloudinaryImageWidget: React.FC<CloudinaryWidgetProps> = ({
         if (src && !src.endsWith("undefined")) {
             setLocalSrc(src);
         }
-        // Poll briefly for the blob to be populated by the CMS proxy
+        // Poll briefly for the blob to be populated by the CMS proxy.
+        // Cap attempts so the interval doesn't leak if the value never
+        // changes (e.g., src was already resolved or stays unresolved).
+        let attempts = 0;
+        const MAX_POLL_ATTEMPTS = 20;
         const interval = setInterval(() => {
+            attempts++;
             const resolved = getAsset(value, field).toString();
             if (resolved && resolved !== src) {
                 setLocalSrc(resolved);
+                clearInterval(interval);
+            } else if (attempts >= MAX_POLL_ATTEMPTS) {
                 clearInterval(interval);
             }
         }, 500);

--- a/src/cms/widgets/CloudinaryImageWidget.tsx
+++ b/src/cms/widgets/CloudinaryImageWidget.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useRef } from "react";
+import React, { useCallback, useEffect, useRef, useState } from "react";
 
 import {
     CLOUDINARY_API_KEY,
@@ -11,10 +11,16 @@ interface ImmutableMap {
     get: (key: string) => unknown;
 }
 
+interface AssetProxy {
+    toString: () => string;
+}
+
 interface CloudinaryWidgetProps {
     value?: string;
     onChange: (value: string) => void;
     entry: ImmutableMap;
+    field: ImmutableMap;
+    getAsset: (path: string, field: ImmutableMap) => AssetProxy;
 }
 
 type CloudinaryWidgetInstance = {
@@ -98,6 +104,8 @@ function getFolderFromEntry(entry: ImmutableMap): string {
 // Cast needed at registration site (cms.tsx) for the same reason.
 const CloudinaryImageWidget: React.FC<CloudinaryWidgetProps> = ({
     entry,
+    field,
+    getAsset,
     onChange,
     value,
 }) => {
@@ -182,6 +190,32 @@ const CloudinaryImageWidget: React.FC<CloudinaryWidgetProps> = ({
 
     const folder = getFolderFromEntry(entry);
     const hasImage = value && value.length > 0;
+    const isUrl = hasImage && value.startsWith("http");
+
+    const [localSrc, setLocalSrc] = useState<string | null>(null);
+    useEffect(() => {
+        if (!hasImage || isUrl) {
+            setLocalSrc(null);
+            return;
+        }
+        // getAsset returns an AssetProxy; its path may resolve async
+        const asset = getAsset(value, field);
+        const src = asset.toString();
+        if (src && !src.endsWith("undefined")) {
+            setLocalSrc(src);
+        }
+        // Poll briefly for the blob to be populated by the CMS proxy
+        const interval = setInterval(() => {
+            const resolved = getAsset(value, field).toString();
+            if (resolved && resolved !== src) {
+                setLocalSrc(resolved);
+                clearInterval(interval);
+            }
+        }, 500);
+        return () => clearInterval(interval);
+    }, [value, field, getAsset, hasImage, isUrl]);
+
+    const previewSrc = isUrl ? value : localSrc;
 
     return (
         <div
@@ -191,10 +225,10 @@ const CloudinaryImageWidget: React.FC<CloudinaryWidgetProps> = ({
                 padding: "12px",
             }}
         >
-            {hasImage && (
+            {hasImage && previewSrc && (
                 <div style={{ marginBottom: "8px" }}>
                     <img
-                        src={value}
+                        src={previewSrc}
                         alt="Uploaded"
                         style={{
                             maxWidth: "100%",

--- a/src/component-queries/DiseaseCellLines.tsx
+++ b/src/component-queries/DiseaseCellLines.tsx
@@ -78,6 +78,7 @@ export default function DiseaseCellLineQuery(props: {
                                                     )
                                                 }
                                             }
+                                            image_url
                                             caption
                                         }
                                     }

--- a/src/component-queries/NormalCellLines.tsx
+++ b/src/component-queries/NormalCellLines.tsx
@@ -55,6 +55,7 @@ export default function NormalCellLines() {
                                             )
                                         }
                                     }
+                                    image_url
                                     caption
                                 }
                             }

--- a/src/component-queries/types.ts
+++ b/src/component-queries/types.ts
@@ -89,7 +89,7 @@ export interface StemCellCharacteristicsFrontmatter {
         day_of_beating_range: string;
     };
     cardiomyocyte_differentiation_caption: string;
-    rnaseq_analysis: UnpackedImageData[];
+    rnaseq_analysis: RawImageData[];
 }
 
 export interface ParentalLineFrontmatter {
@@ -200,12 +200,12 @@ export interface Sequence {
     type: string;
 }
 
-export interface SingleImageDiagram extends UnpackedImageData {
+export interface SingleImageDiagram extends RawImageData {
     title: string;
 }
 
 export interface DiagramList {
-    images: UnpackedImageData[];
+    images: RawImageData[];
     title: string;
 }
 

--- a/src/component-queries/types.ts
+++ b/src/component-queries/types.ts
@@ -1,5 +1,8 @@
 import { IGatsbyImageData } from "gatsby-plugin-image";
 
+// Image can be either GatsbyImage(local) or a url string(cloud)
+export type ImageSource = IGatsbyImageData | string;
+
 // this is the image that comes from the CMS
 // without any data processing
 // it's just the user entered data
@@ -25,12 +28,13 @@ export interface RawImageData {
         childImageSharp: {
             gatsbyImageData: IGatsbyImageData;
         };
-    };
+    } | null;
+    image_url?: string | null;
     caption: string;
 }
 
 export interface UnpackedImageData {
-    image: IGatsbyImageData;
+    image: ImageSource;
     caption: string;
 }
 
@@ -266,7 +270,7 @@ export interface UnpackedCellLineMainInfo {
     certificateOfAnalysis: string;
     healthCertificate: string;
     orderLink: string;
-    thumbnailImage?: IGatsbyImageData | null;
+    thumbnailImage?: ImageSource | null;
     imagesAndVideos?: MediaFrontmatter;
 }
 

--- a/src/components/CellLineTable/SharedColumns.tsx
+++ b/src/components/CellLineTable/SharedColumns.tsx
@@ -2,7 +2,7 @@ import Icon from "@ant-design/icons";
 import { Flex, Tooltip } from "antd";
 import classNames from "classnames";
 import { Link } from "gatsby";
-import { GatsbyImage, getImage } from "gatsby-plugin-image";
+import { GatsbyImage, IGatsbyImageData, getImage } from "gatsby-plugin-image";
 import React from "react";
 
 import { CellLineStatus } from "../../component-queries/types";
@@ -34,21 +34,36 @@ export const cellLineIdColumn = {
         const cellLine = (
             <h4 key={cellLineId}>{formatCellLineId(cellLineId)}</h4>
         );
-        const thumbnailImage = getImage(record.thumbnailImage || null);
+        const thumbnailSrc = record.thumbnailImage;
+        const isUrl = typeof thumbnailSrc === "string";
+        const gatsbyImage = !isUrl ? getImage(thumbnailSrc || null) : null;
 
-        const content = thumbnailImage ? (
-            <>
-                <div className={idHeader}>{cellLine}</div>
-                <div className={thumbnailContainer}>
-                    <GatsbyImage
-                        image={thumbnailImage}
-                        alt={`${cellLine} thumbnail`}
-                    />
-                </div>
-            </>
-        ) : (
-            <div className={idTitle}>{cellLine}</div>
-        );
+        const content =
+            isUrl || gatsbyImage ? (
+                <>
+                    <div className={idHeader}>{cellLine}</div>
+                    <div className={thumbnailContainer}>
+                        {isUrl ? (
+                            <img
+                                src={thumbnailSrc}
+                                alt={`${cellLine} thumbnail`}
+                                style={{
+                                    width: "100%",
+                                    height: "100%",
+                                    objectFit: "cover",
+                                }}
+                            />
+                        ) : (
+                            <GatsbyImage
+                                image={gatsbyImage as IGatsbyImageData}
+                                alt={`${cellLine} thumbnail`}
+                            />
+                        )}
+                    </div>
+                </>
+            ) : (
+                <div className={idTitle}>{cellLine}</div>
+            );
 
         return record.status === CellLineStatus.DataComplete ? (
             <Link to={record.path}>{content}</Link>

--- a/src/components/CellLineTable/SharedColumns.tsx
+++ b/src/components/CellLineTable/SharedColumns.tsx
@@ -2,14 +2,16 @@ import Icon from "@ant-design/icons";
 import { Flex, Tooltip } from "antd";
 import classNames from "classnames";
 import { Link } from "gatsby";
-import { GatsbyImage, IGatsbyImageData, getImage } from "gatsby-plugin-image";
+import { getImage } from "gatsby-plugin-image";
 import React from "react";
 
 import { CellLineStatus } from "../../component-queries/types";
 import CertificateIcon from "../../img/cert-icon.svg";
 import { WHITE } from "../../style/theme";
 import { formatCellLineId, openLinkInNewTab } from "../../utils";
+import { isExternalUrl } from "../../utils/mediaUtils";
 import TubeIcon from "../Icons/TubeIcon";
+import ImageRenderer from "../shared/ImageRenderer";
 import { UnpackedCellLine, mdBreakpoint } from "./types";
 
 const {
@@ -35,35 +37,28 @@ export const cellLineIdColumn = {
             <h4 key={cellLineId}>{formatCellLineId(cellLineId)}</h4>
         );
         const thumbnailSrc = record.thumbnailImage;
-        const isUrl = typeof thumbnailSrc === "string";
-        const gatsbyImage = !isUrl ? getImage(thumbnailSrc || null) : null;
+        const hasImage =
+            thumbnailSrc &&
+            (isExternalUrl(thumbnailSrc) || getImage(thumbnailSrc));
 
-        const content =
-            isUrl || gatsbyImage ? (
-                <>
-                    <div className={idHeader}>{cellLine}</div>
-                    <div className={thumbnailContainer}>
-                        {isUrl ? (
-                            <img
-                                src={thumbnailSrc}
-                                alt={`${cellLine} thumbnail`}
-                                style={{
-                                    width: "100%",
-                                    height: "100%",
-                                    objectFit: "cover",
-                                }}
-                            />
-                        ) : (
-                            <GatsbyImage
-                                image={gatsbyImage as IGatsbyImageData}
-                                alt={`${cellLine} thumbnail`}
-                            />
-                        )}
-                    </div>
-                </>
-            ) : (
-                <div className={idTitle}>{cellLine}</div>
-            );
+        const content = hasImage ? (
+            <>
+                <div className={idHeader}>{cellLine}</div>
+                <div className={thumbnailContainer}>
+                    <ImageRenderer
+                        image={thumbnailSrc!}
+                        alt={`${formatCellLineId(cellLineId)} thumbnail`}
+                        style={{
+                            width: "100%",
+                            height: "100%",
+                            objectFit: "cover",
+                        }}
+                    />
+                </div>
+            </>
+        ) : (
+            <div className={idTitle}>{cellLine}</div>
+        );
 
         return record.status === CellLineStatus.DataComplete ? (
             <Link to={record.path}>{content}</Link>

--- a/src/components/ImagesAndVideo/ImagePreviewGroup.tsx
+++ b/src/components/ImagesAndVideo/ImagePreviewGroup.tsx
@@ -4,6 +4,7 @@ import { getSrc } from "gatsby-plugin-image";
 import React from "react";
 
 import { ImageOrVideo, UnpackedImageData } from "../../component-queries/types";
+import { isCloudinaryUrl } from "../../utils/mediaUtils";
 
 interface ImagePreviewGroupProps {
     mediaItems: ImageOrVideo[];
@@ -30,10 +31,13 @@ export const PreviewGroup = ({
     setSelectedMedia,
 }: ImagePreviewGroupProps) => {
     const allPreviewImages = imageItems.map((item, i) => {
+        const src = isCloudinaryUrl(item.image)
+            ? item.image
+            : getSrc(item.image);
         return (
             <Image
                 key={`preview-${i}`}
-                src={getSrc(item.image)}
+                src={src}
                 style={{ display: "none" }}
                 className={previewImage}
             />

--- a/src/components/ImagesAndVideo/ImagePreviewGroup.tsx
+++ b/src/components/ImagesAndVideo/ImagePreviewGroup.tsx
@@ -4,7 +4,7 @@ import { getSrc } from "gatsby-plugin-image";
 import React from "react";
 
 import { ImageOrVideo, UnpackedImageData } from "../../component-queries/types";
-import { isCloudinaryUrl } from "../../utils/mediaUtils";
+import { isExternalUrl } from "../../utils/mediaUtils";
 
 interface ImagePreviewGroupProps {
     mediaItems: ImageOrVideo[];
@@ -31,9 +31,7 @@ export const PreviewGroup = ({
     setSelectedMedia,
 }: ImagePreviewGroupProps) => {
     const allPreviewImages = imageItems.map((item, i) => {
-        const src = isCloudinaryUrl(item.image)
-            ? item.image
-            : getSrc(item.image);
+        const src = isExternalUrl(item.image) ? item.image : getSrc(item.image);
         return (
             <Image
                 key={`preview-${i}`}

--- a/src/components/ImagesAndVideo/MediaCard.tsx
+++ b/src/components/ImagesAndVideo/MediaCard.tsx
@@ -40,7 +40,8 @@ const renderMediaContent = (
                 image={item.image}
                 alt="Cell line media"
                 className={className}
-                style={{ objectFit: "contain", maxWidth: "100%" }}
+                style={{ maxWidth: "100%" }}
+                imgStyle={{ objectFit: "contain" }}
                 onClick={onClickHandler}
             />
         );

--- a/src/components/ImagesAndVideo/MediaCard.tsx
+++ b/src/components/ImagesAndVideo/MediaCard.tsx
@@ -1,9 +1,9 @@
 import { Card, Flex } from "antd";
-import { GatsbyImage } from "gatsby-plugin-image";
 import React from "react";
 
 import { ImageOrVideo } from "../../component-queries/types";
-import { isExternalUrl, isImage } from "../../utils/mediaUtils";
+import { isImage } from "../../utils/mediaUtils";
+import ImageRenderer from "../shared/ImageRenderer";
 
 const {
     caption,
@@ -35,28 +35,12 @@ const renderMediaContent = (
     const isImageItem = isImage(item);
 
     if (isImageItem) {
-        if (isExternalUrl(item.image)) {
-            return (
-                <img
-                    className={className}
-                    src={item.image}
-                    alt="Cell line media"
-                    style={{
-                        objectFit: "contain",
-                        cursor: onClickHandler ? "pointer" : undefined,
-                        maxWidth: "100%",
-                    }}
-                    onClick={onClickHandler}
-                />
-            );
-        }
         return (
-            <GatsbyImage
-                className={className}
+            <ImageRenderer
                 image={item.image}
                 alt="Cell line media"
-                imgStyle={{ objectFit: "contain" }}
-                style={onClickHandler ? { cursor: "pointer" } : undefined}
+                className={className}
+                style={{ objectFit: "contain", maxWidth: "100%" }}
                 onClick={onClickHandler}
             />
         );

--- a/src/components/ImagesAndVideo/MediaCard.tsx
+++ b/src/components/ImagesAndVideo/MediaCard.tsx
@@ -3,7 +3,7 @@ import { GatsbyImage } from "gatsby-plugin-image";
 import React from "react";
 
 import { ImageOrVideo } from "../../component-queries/types";
-import { isCloudinaryUrl, isImage } from "../../utils/mediaUtils";
+import { isExternalUrl, isImage } from "../../utils/mediaUtils";
 
 const {
     caption,
@@ -35,7 +35,7 @@ const renderMediaContent = (
     const isImageItem = isImage(item);
 
     if (isImageItem) {
-        if (isCloudinaryUrl(item.image)) {
+        if (isExternalUrl(item.image)) {
             return (
                 <img
                     className={className}

--- a/src/components/ImagesAndVideo/MediaCard.tsx
+++ b/src/components/ImagesAndVideo/MediaCard.tsx
@@ -3,7 +3,7 @@ import { GatsbyImage } from "gatsby-plugin-image";
 import React from "react";
 
 import { ImageOrVideo } from "../../component-queries/types";
-import { isImage } from "../../utils/mediaUtils";
+import { isCloudinaryUrl, isImage } from "../../utils/mediaUtils";
 
 const {
     caption,
@@ -35,6 +35,21 @@ const renderMediaContent = (
     const isImageItem = isImage(item);
 
     if (isImageItem) {
+        if (isCloudinaryUrl(item.image)) {
+            return (
+                <img
+                    className={className}
+                    src={item.image}
+                    alt="Cell line media"
+                    style={{
+                        objectFit: "contain",
+                        cursor: onClickHandler ? "pointer" : undefined,
+                        maxWidth: "100%",
+                    }}
+                    onClick={onClickHandler}
+                />
+            );
+        }
         return (
             <GatsbyImage
                 className={className}

--- a/src/components/ParentalLineModal.tsx
+++ b/src/components/ParentalLineModal.tsx
@@ -1,13 +1,12 @@
 import Icon, { InfoCircleOutlined } from "@ant-design/icons";
 import { Descriptions, Divider, Flex, Modal } from "antd";
-import { GatsbyImage, IGatsbyImageData, getImage } from "gatsby-plugin-image";
 import React, { useState } from "react";
 
 import { ImageSource, UnpackedGene } from "../component-queries/types";
 import LinkOutIcon from "../img/external-link.svg";
 import { formatCellLineSlug } from "../utils";
-import { isExternalUrl } from "../utils/mediaUtils";
 import { DarkBlueHoverButton } from "./shared/Buttons";
+import ImageRenderer from "./shared/ImageRenderer";
 
 const {
     actionButton,
@@ -45,9 +44,6 @@ const ParentalLineModal = (props: ParentalLineModalProps) => {
         setIsModalOpen(false);
     };
     const rawImage = props.image;
-    const isUrl = rawImage ? isExternalUrl(rawImage) : false;
-    const image =
-        !isUrl && rawImage ? getImage(rawImage as IGatsbyImageData) : null;
     const headerElement = (
         <div className={header}>
             <div className={title}>Parental Line </div>
@@ -124,22 +120,17 @@ const ParentalLineModal = (props: ParentalLineModalProps) => {
             >
                 <Flex justify="space-between" gap={16}>
                     <div style={{ width: "192px", display: "block" }}>
-                        {isUrl && rawImage ? (
-                            <img
+                        {rawImage && (
+                            <ImageRenderer
+                                image={rawImage}
                                 alt={`${props.formattedId} thumbnail image`}
-                                src={rawImage as string}
                                 style={{
                                     width: 192,
                                     height: 192,
                                     objectFit: "cover",
                                 }}
                             />
-                        ) : image ? (
-                            <GatsbyImage
-                                alt={`${props.formattedId} thumbnail image`}
-                                image={image}
-                            />
-                        ) : null}
+                        )}
                     </div>
                     <Descriptions
                         column={1}

--- a/src/components/ParentalLineModal.tsx
+++ b/src/components/ParentalLineModal.tsx
@@ -6,7 +6,7 @@ import React, { useState } from "react";
 import { ImageSource, UnpackedGene } from "../component-queries/types";
 import LinkOutIcon from "../img/external-link.svg";
 import { formatCellLineSlug } from "../utils";
-import { isCloudinaryUrl } from "../utils/mediaUtils";
+import { isExternalUrl } from "../utils/mediaUtils";
 import { DarkBlueHoverButton } from "./shared/Buttons";
 
 const {
@@ -45,7 +45,7 @@ const ParentalLineModal = (props: ParentalLineModalProps) => {
         setIsModalOpen(false);
     };
     const rawImage = props.image;
-    const isUrl = rawImage ? isCloudinaryUrl(rawImage) : false;
+    const isUrl = rawImage ? isExternalUrl(rawImage) : false;
     const image =
         !isUrl && rawImage ? getImage(rawImage as IGatsbyImageData) : null;
     const headerElement = (

--- a/src/components/ParentalLineModal.tsx
+++ b/src/components/ParentalLineModal.tsx
@@ -3,9 +3,10 @@ import { Descriptions, Divider, Flex, Modal } from "antd";
 import { GatsbyImage, IGatsbyImageData, getImage } from "gatsby-plugin-image";
 import React, { useState } from "react";
 
-import { UnpackedGene } from "../component-queries/types";
+import { ImageSource, UnpackedGene } from "../component-queries/types";
 import LinkOutIcon from "../img/external-link.svg";
 import { formatCellLineSlug } from "../utils";
+import { isCloudinaryUrl } from "../utils/mediaUtils";
 import { DarkBlueHoverButton } from "./shared/Buttons";
 
 const {
@@ -20,7 +21,7 @@ const {
 } = require("../style/modal.module.css");
 
 interface ParentalLineModalProps {
-    image?: IGatsbyImageData | null;
+    image?: ImageSource | null;
     formattedId: string;
     cellLineId: number;
     cloneNumber: number;
@@ -43,7 +44,10 @@ const ParentalLineModal = (props: ParentalLineModalProps) => {
         props.suppressRowClickRef.current = false;
         setIsModalOpen(false);
     };
-    const image = getImage(props.image ?? null);
+    const rawImage = props.image;
+    const isUrl = rawImage ? isCloudinaryUrl(rawImage) : false;
+    const image =
+        !isUrl && rawImage ? getImage(rawImage as IGatsbyImageData) : null;
     const headerElement = (
         <div className={header}>
             <div className={title}>Parental Line </div>
@@ -120,12 +124,22 @@ const ParentalLineModal = (props: ParentalLineModalProps) => {
             >
                 <Flex justify="space-between" gap={16}>
                     <div style={{ width: "192px", display: "block" }}>
-                        {image && (
+                        {isUrl && rawImage ? (
+                            <img
+                                alt={`${props.formattedId} thumbnail image`}
+                                src={rawImage as string}
+                                style={{
+                                    width: 192,
+                                    height: 192,
+                                    objectFit: "cover",
+                                }}
+                            />
+                        ) : image ? (
                             <GatsbyImage
                                 alt={`${props.formattedId} thumbnail image`}
                                 image={image}
                             />
-                        )}
+                        ) : null}
                     </div>
                     <Descriptions
                         column={1}

--- a/src/components/SubPage/convert-data.ts
+++ b/src/components/SubPage/convert-data.ts
@@ -14,7 +14,7 @@ import {
     StemCellCharacteristicsFrontmatter,
 } from "../../component-queries/types";
 import { hasTableData, nonEmptyArray } from "../../utils";
-import { getThumbnail } from "../../utils/mediaUtils";
+import { getThumbnail, unpackImageData } from "../../utils/mediaUtils";
 import { DiagramCardProps } from "../shared/DiagramCard";
 import { PERCENT_POS_CAPTION } from "./stem-cell-table-constants";
 import {
@@ -35,13 +35,17 @@ export const unpackDiagrams = (
     if (!diagrams || diagrams.length === 0) {
         return [];
     }
-    return diagrams.map((diagram) => {
-        return {
+    const result: DiagramCardProps[] = [];
+    diagrams.forEach((diagram) => {
+        const unpacked = unpackImageData(diagram);
+        if (!unpacked) return;
+        result.push({
             title: diagram.title,
-            caption: diagram.caption,
-            image: diagram.image,
-        };
+            caption: unpacked.caption,
+            image: unpacked.image,
+        });
     });
+    return result;
 };
 
 export const unpackMultiImageDiagrams = (
@@ -59,10 +63,12 @@ export const unpackMultiImageDiagrams = (
         }
 
         diagram.images.forEach((imageObj, index) => {
+            const unpacked = unpackImageData(imageObj);
+            if (!unpacked) return;
             result.push({
                 title: index === 0 ? diagram.title : "",
-                caption: imageObj.caption,
-                image: imageObj.image,
+                caption: unpacked.caption,
+                image: unpacked.image,
             });
         });
     });
@@ -275,13 +281,16 @@ export const unpackNormalStemCellCharacteristics = (
             : [],
     };
 
-    const rnaSeqAnalysis: DiagramCardProps[] = (scc.rnaseq_analysis ?? []).map(
-        (item) => ({
+    const rnaSeqAnalysis: DiagramCardProps[] = [];
+    (scc.rnaseq_analysis ?? []).forEach((item) => {
+        const unpacked = unpackImageData(item);
+        if (!unpacked) return;
+        rnaSeqAnalysis.push({
             title: "RNASEQ", // TODO get appropriate title for this card
-            image: item.image,
-            caption: item.caption,
-        }),
-    );
+            image: unpacked.image,
+            caption: unpacked.caption,
+        });
+    });
 
     return {
         pluripotencyAnalysis,

--- a/src/components/Thumbnail.tsx
+++ b/src/components/Thumbnail.tsx
@@ -3,7 +3,7 @@ import { GatsbyImage, IGatsbyImageData } from "gatsby-plugin-image";
 import React from "react";
 
 import { ImageSource } from "../component-queries/types";
-import { isCloudinaryUrl } from "../utils/mediaUtils";
+import { isExternalUrl } from "../utils/mediaUtils";
 
 const {
     selectedThumbnail,
@@ -33,7 +33,7 @@ const Thumbnail: React.FC<ThumbnailProps> = ({
 }) => {
     const renderImage = () => {
         if (!image) return null;
-        if (isCloudinaryUrl(image)) {
+        if (isExternalUrl(image)) {
             return (
                 <img
                     src={image}

--- a/src/components/Thumbnail.tsx
+++ b/src/components/Thumbnail.tsx
@@ -1,9 +1,8 @@
 import classNames from "classnames";
-import { GatsbyImage, IGatsbyImageData } from "gatsby-plugin-image";
 import React from "react";
 
 import { ImageSource } from "../component-queries/types";
-import { isExternalUrl } from "../utils/mediaUtils";
+import ImageRenderer from "./shared/ImageRenderer";
 
 const {
     selectedThumbnail,
@@ -31,29 +30,6 @@ const Thumbnail: React.FC<ThumbnailProps> = ({
     type = "image",
     videoId,
 }) => {
-    const renderImage = () => {
-        if (!image) return null;
-        if (isExternalUrl(image)) {
-            return (
-                <img
-                    src={image}
-                    alt="thumbnail image"
-                    style={{
-                        width: "100%",
-                        height: "100%",
-                        objectFit: "cover",
-                    }}
-                />
-            );
-        }
-        return (
-            <GatsbyImage
-                image={image as IGatsbyImageData}
-                alt="thumbnail image"
-            />
-        );
-    };
-
     return (
         <div
             onClick={onClick}
@@ -64,7 +40,15 @@ const Thumbnail: React.FC<ThumbnailProps> = ({
             role="button"
         >
             {type === "image" && image ? (
-                renderImage()
+                <ImageRenderer
+                    image={image}
+                    alt="thumbnail image"
+                    style={{
+                        width: "100%",
+                        height: "100%",
+                        objectFit: "cover",
+                    }}
+                />
             ) : (
                 <img
                     src={getVimeoThumbnail(videoId || "") ?? ""}

--- a/src/components/Thumbnail.tsx
+++ b/src/components/Thumbnail.tsx
@@ -2,6 +2,9 @@ import classNames from "classnames";
 import { GatsbyImage, IGatsbyImageData } from "gatsby-plugin-image";
 import React from "react";
 
+import { ImageSource } from "../component-queries/types";
+import { isCloudinaryUrl } from "../utils/mediaUtils";
+
 const {
     selectedThumbnail,
     thumbnail,
@@ -10,7 +13,7 @@ const {
 } = require("../style/thumbnail.module.css");
 
 interface ThumbnailProps {
-    image?: IGatsbyImageData;
+    image?: ImageSource;
     videoId?: string;
     isSelected: boolean;
     onClick: () => void;
@@ -28,6 +31,29 @@ const Thumbnail: React.FC<ThumbnailProps> = ({
     type = "image",
     videoId,
 }) => {
+    const renderImage = () => {
+        if (!image) return null;
+        if (isCloudinaryUrl(image)) {
+            return (
+                <img
+                    src={image}
+                    alt="thumbnail image"
+                    style={{
+                        width: "100%",
+                        height: "100%",
+                        objectFit: "cover",
+                    }}
+                />
+            );
+        }
+        return (
+            <GatsbyImage
+                image={image as IGatsbyImageData}
+                alt="thumbnail image"
+            />
+        );
+    };
+
     return (
         <div
             onClick={onClick}
@@ -38,7 +64,7 @@ const Thumbnail: React.FC<ThumbnailProps> = ({
             role="button"
         >
             {type === "image" && image ? (
-                <GatsbyImage image={image} alt="thumbnail image" />
+                renderImage()
             ) : (
                 <img
                     src={getVimeoThumbnail(videoId || "") ?? ""}

--- a/src/components/shared/DiagramCard.tsx
+++ b/src/components/shared/DiagramCard.tsx
@@ -1,10 +1,9 @@
 import { CardProps } from "antd";
 import classNames from "classnames";
-import { GatsbyImage, getImage } from "gatsby-plugin-image";
 import React from "react";
 
 import { ImageSource } from "../../component-queries/types";
-import { isExternalUrl } from "../../utils/mediaUtils";
+import ImageRenderer from "./ImageRenderer";
 import SubpageContentCard from "./SubpageContentCard";
 
 const { container } = require("../../style/diagram-card.module.css");
@@ -29,8 +28,6 @@ const DiagramCard: React.FC<DiagramCardProps> = ({
     }
 
     const cardTitle = headerLeadText ? `${headerLeadText}: ${title}` : title;
-    const isUrl = isExternalUrl(image);
-    const imageData = !isUrl ? getImage(image) : null;
 
     return (
         <SubpageContentCard
@@ -39,19 +36,11 @@ const DiagramCard: React.FC<DiagramCardProps> = ({
             caption={caption}
             className={classNames(container, className)}
         >
-            {isUrl ? (
-                <img
-                    style={{ marginBottom: 16, maxWidth: "100%" }}
-                    src={image}
-                    alt={cardTitle || "diagram"}
-                />
-            ) : imageData ? (
-                <GatsbyImage
-                    style={{ marginBottom: 16 }}
-                    image={imageData}
-                    alt={cardTitle || "diagram"}
-                />
-            ) : null}
+            <ImageRenderer
+                image={image}
+                alt={cardTitle || "diagram"}
+                style={{ marginBottom: 16, maxWidth: "100%" }}
+            />
         </SubpageContentCard>
     );
 };

--- a/src/components/shared/DiagramCard.tsx
+++ b/src/components/shared/DiagramCard.tsx
@@ -1,15 +1,17 @@
 import { CardProps } from "antd";
 import classNames from "classnames";
-import { GatsbyImage, IGatsbyImageData, getImage } from "gatsby-plugin-image";
+import { GatsbyImage, getImage } from "gatsby-plugin-image";
 import React from "react";
 
+import { ImageSource } from "../../component-queries/types";
+import { isCloudinaryUrl } from "../../utils/mediaUtils";
 import SubpageContentCard from "./SubpageContentCard";
 
 const { container } = require("../../style/diagram-card.module.css");
 
 export interface DiagramCardProps extends CardProps {
     title?: string;
-    image?: IGatsbyImageData;
+    image?: ImageSource;
     caption?: string;
     headerLeadText?: string;
 }
@@ -25,9 +27,10 @@ const DiagramCard: React.FC<DiagramCardProps> = ({
     if (!image) {
         return null;
     }
-    const imageData = getImage(image);
 
     const cardTitle = headerLeadText ? `${headerLeadText}: ${title}` : title;
+    const isUrl = isCloudinaryUrl(image);
+    const imageData = !isUrl ? getImage(image) : null;
 
     return (
         <SubpageContentCard
@@ -36,13 +39,19 @@ const DiagramCard: React.FC<DiagramCardProps> = ({
             caption={caption}
             className={classNames(container, className)}
         >
-            {imageData && (
+            {isUrl ? (
+                <img
+                    style={{ marginBottom: 16, maxWidth: "100%" }}
+                    src={image}
+                    alt={cardTitle || "diagram"}
+                />
+            ) : imageData ? (
                 <GatsbyImage
                     style={{ marginBottom: 16 }}
                     image={imageData}
                     alt={cardTitle || "diagram"}
                 />
-            )}
+            ) : null}
         </SubpageContentCard>
     );
 };

--- a/src/components/shared/DiagramCard.tsx
+++ b/src/components/shared/DiagramCard.tsx
@@ -4,7 +4,7 @@ import { GatsbyImage, getImage } from "gatsby-plugin-image";
 import React from "react";
 
 import { ImageSource } from "../../component-queries/types";
-import { isCloudinaryUrl } from "../../utils/mediaUtils";
+import { isExternalUrl } from "../../utils/mediaUtils";
 import SubpageContentCard from "./SubpageContentCard";
 
 const { container } = require("../../style/diagram-card.module.css");
@@ -29,7 +29,7 @@ const DiagramCard: React.FC<DiagramCardProps> = ({
     }
 
     const cardTitle = headerLeadText ? `${headerLeadText}: ${title}` : title;
-    const isUrl = isCloudinaryUrl(image);
+    const isUrl = isExternalUrl(image);
     const imageData = !isUrl ? getImage(image) : null;
 
     return (

--- a/src/components/shared/ImageRenderer.tsx
+++ b/src/components/shared/ImageRenderer.tsx
@@ -1,0 +1,45 @@
+import { GatsbyImage, IGatsbyImageData } from "gatsby-plugin-image";
+import React from "react";
+
+import { ImageSource } from "../../component-queries/types";
+import { isExternalUrl } from "../../utils/mediaUtils";
+
+interface ImageRendererProps {
+    image: ImageSource;
+    alt: string;
+    className?: string;
+    style?: React.CSSProperties;
+    onClick?: () => void;
+}
+
+// handle both Gatsby image data and external URLs
+const ImageRenderer: React.FC<ImageRendererProps> = ({
+    alt,
+    className,
+    image,
+    onClick,
+    style,
+}) => {
+    if (isExternalUrl(image)) {
+        return (
+            <img
+                src={image}
+                alt={alt}
+                className={className}
+                style={style}
+                onClick={onClick}
+            />
+        );
+    }
+    return (
+        <GatsbyImage
+            image={image as IGatsbyImageData}
+            alt={alt}
+            className={className}
+            style={onClick ? { cursor: "pointer", ...style } : style}
+            onClick={onClick}
+        />
+    );
+};
+
+export default ImageRenderer;

--- a/src/components/shared/ImageRenderer.tsx
+++ b/src/components/shared/ImageRenderer.tsx
@@ -1,4 +1,4 @@
-import { GatsbyImage, IGatsbyImageData } from "gatsby-plugin-image";
+import { GatsbyImage, IGatsbyImageData, getImage } from "gatsby-plugin-image";
 import React from "react";
 
 import { ImageSource } from "../../component-queries/types";
@@ -9,6 +9,7 @@ interface ImageRendererProps {
     alt: string;
     className?: string;
     style?: React.CSSProperties;
+    imgStyle?: React.CSSProperties;
     onClick?: () => void;
 }
 
@@ -17,6 +18,7 @@ const ImageRenderer: React.FC<ImageRendererProps> = ({
     alt,
     className,
     image,
+    imgStyle,
     onClick,
     style,
 }) => {
@@ -26,17 +28,20 @@ const ImageRenderer: React.FC<ImageRendererProps> = ({
                 src={image}
                 alt={alt}
                 className={className}
-                style={style}
+                style={{ ...style, ...imgStyle }}
                 onClick={onClick}
             />
         );
     }
+    const resolved = getImage(image as IGatsbyImageData);
+    if (!resolved) return null;
     return (
         <GatsbyImage
-            image={image as IGatsbyImageData}
+            image={resolved}
             alt={alt}
             className={className}
             style={onClick ? { cursor: "pointer", ...style } : style}
+            imgStyle={imgStyle}
             onClick={onClick}
         />
     );

--- a/src/style/images-and-videos.module.css
+++ b/src/style/images-and-videos.module.css
@@ -5,8 +5,7 @@
     flex-direction: column;
     overflow: hidden;
     flex: 1 1 auto;
-    max-height: 870px;
-    height: 100%;
+    height: 689px;
 }
 
 .container :global(.ant-card-head) {

--- a/src/templates/cell-line.tsx
+++ b/src/templates/cell-line.tsx
@@ -178,6 +178,7 @@ export const pageQuery = graphql`
                                 )
                             }
                         }
+                        image_url
                         caption
                     }
                     videos {
@@ -201,6 +202,7 @@ export const pageQuery = graphql`
                                     )
                                 }
                             }
+                            image_url
                             caption
                         }
                     }
@@ -217,6 +219,7 @@ export const pageQuery = graphql`
                                     )
                                 }
                             }
+                            image_url
                             caption
                         }
                     }
@@ -269,6 +272,7 @@ export const pageQuery = graphql`
                                 )
                             }
                         }
+                        image_url
                         caption
                     }
                 }

--- a/src/templates/disease-catalog.tsx
+++ b/src/templates/disease-catalog.tsx
@@ -112,7 +112,9 @@ interface QueryResult {
 const DiseaseCatalog = ({ data }: QueryResult) => {
     const { markdownRemark: post } = data;
     const imageFile = post.frontmatter.header?.background;
-    const backgroundImageUrl = getImageSrcFromFileNode(imageFile!);
+    const backgroundImageUrl = imageFile
+        ? getImageSrcFromFileNode(imageFile)
+        : undefined;
     return (
         <Layout
             header={

--- a/src/templates/disease-catalog.tsx
+++ b/src/templates/disease-catalog.tsx
@@ -86,6 +86,7 @@ interface QueryResult {
                     title?: string;
                     subtitle?: string;
                     background?: FileNode;
+                    background_url?: string | null;
                 };
                 footer_text: {
                     html: string;
@@ -112,9 +113,10 @@ interface QueryResult {
 const DiseaseCatalog = ({ data }: QueryResult) => {
     const { markdownRemark: post } = data;
     const imageFile = post.frontmatter.header?.background;
-    const backgroundImageUrl = imageFile
-        ? getImageSrcFromFileNode(imageFile)
-        : undefined;
+    const backgroundImageUrl =
+        (imageFile ? getImageSrcFromFileNode(imageFile) : undefined) ??
+        post.frontmatter.header?.background_url ??
+        undefined;
     return (
         <Layout
             header={
@@ -157,6 +159,7 @@ export const aboutPageQuery = graphql`
                             )
                         }
                     }
+                    background_url
                 }
                 footer_text {
                     html

--- a/src/templates/disease-cell-line.tsx
+++ b/src/templates/disease-cell-line.tsx
@@ -194,6 +194,7 @@ export const pageQuery = graphql`
                                 )
                             }
                         }
+                        image_url
                         caption
                     }
                 }
@@ -217,6 +218,7 @@ export const pageQuery = graphql`
                                     )
                                 }
                             }
+                            image_url
                             caption
                         }
                     }
@@ -232,6 +234,7 @@ export const pageQuery = graphql`
                                 )
                             }
                         }
+                        image_url
                         caption
                     }
                 }

--- a/src/templates/normal-catalog.tsx
+++ b/src/templates/normal-catalog.tsx
@@ -52,6 +52,7 @@ interface QueryResult {
                     title?: string;
                     subtitle?: string;
                     background?: FileNode;
+                    background_url?: string | null;
                 };
                 funding_text: {
                     html: string;
@@ -70,9 +71,10 @@ interface QueryResult {
 const NormalCatalog = ({ data }: QueryResult) => {
     const { markdownRemark: post } = data;
     const imageFile = post.frontmatter.header?.background;
-    const backgroundImageUrl = imageFile
-        ? getImageSrcFromFileNode(imageFile)
-        : undefined;
+    const backgroundImageUrl =
+        (imageFile ? getImageSrcFromFileNode(imageFile) : undefined) ??
+        post.frontmatter.header?.background_url ??
+        undefined;
     return (
         <Layout
             header={
@@ -118,6 +120,7 @@ export const aboutPageQuery = graphql`
                             )
                         }
                     }
+                    background_url
                 }
                 funding_text {
                     html

--- a/src/utils/mediaUtils.ts
+++ b/src/utils/mediaUtils.ts
@@ -10,7 +10,7 @@ import {
     UnpackedImageData,
 } from "../component-queries/types";
 
-export function isCloudinaryUrl(image: ImageSource): image is string {
+export function isExternalUrl(image: ImageSource): image is string {
     return typeof image === "string";
 }
 
@@ -60,6 +60,6 @@ export const getThumbnail = (
 ): ImageSource | null => {
     const firstImage = getImages(imagesAndVideos)[0];
     if (!firstImage) return null;
-    if (isCloudinaryUrl(firstImage.image)) return firstImage.image;
+    if (isExternalUrl(firstImage.image)) return firstImage.image;
     return getImage(firstImage.image) ?? null;
 };

--- a/src/utils/mediaUtils.ts
+++ b/src/utils/mediaUtils.ts
@@ -1,38 +1,65 @@
-import { getImage, IGatsbyImageData } from "gatsby-plugin-image";
-import { RawImageData, UnpackedImageData, RawVideoData, MediaFrontmatter, ImageOrVideo } from "../component-queries/types";
+import { getImage } from "gatsby-plugin-image";
 import { FileNode } from "gatsby-plugin-image/dist/src/components/hooks";
+
+import {
+    ImageOrVideo,
+    ImageSource,
+    MediaFrontmatter,
+    RawImageData,
+    RawVideoData,
+    UnpackedImageData,
+} from "../component-queries/types";
+
+export function isCloudinaryUrl(image: ImageSource): image is string {
+    return typeof image === "string";
+}
 
 // type guard to distinguish images and videos at runtime
 export function isImage(item: ImageOrVideo): item is UnpackedImageData {
-  return "image" in item;
+    return "image" in item;
 }
 
-export const getImageSrcFromFileNode = (file: FileNode): string | undefined  => {
-  return file.childImageSharp?.gatsbyImageData?.images?.fallback?.src;
-}
+export const getImageSrcFromFileNode = (file: FileNode): string | undefined => {
+    return file.childImageSharp?.gatsbyImageData?.images?.fallback?.src;
+};
 
 // flatten and validate image data
-export function unpackImageData(
-  x: RawImageData
-): UnpackedImageData | null {
-  return { image: x.image.childImageSharp.gatsbyImageData, caption: x.caption };
+export function unpackImageData(x: RawImageData): UnpackedImageData | null {
+    if (!x) return null;
+    // Gatsby image: image.childImageSharp.gatsbyImageData
+    if (x.image?.childImageSharp?.gatsbyImageData) {
+        return {
+            image: x.image.childImageSharp.gatsbyImageData,
+            caption: x.caption,
+        };
+    }
+    // Cloudinary url: image is null (file can't resolve), use image_url
+    if (x.image_url) {
+        return { image: x.image_url, caption: x.caption };
+    }
+    return null;
 }
 
 export const hasMedia = (rawMedia?: MediaFrontmatter): boolean => {
-  return Boolean(rawMedia?.images?.length || rawMedia?.videos?.length);
+    return Boolean(rawMedia?.images?.length || rawMedia?.videos?.length);
 };
 
 export const getImages = (raw?: MediaFrontmatter): UnpackedImageData[] => {
-  const media = (raw?.images ?? []);
-  return media.map(unpackImageData)
-    .filter((x): x is UnpackedImageData => x !== null);
-}
-
-export const getVideos = (rawMedia?: MediaFrontmatter): RawVideoData[] => {
-  return rawMedia?.videos || [];
+    const media = raw?.images ?? [];
+    return media
+        .map(unpackImageData)
+        .filter((x): x is UnpackedImageData => x !== null);
 };
 
-export const getThumbnail = (imagesAndVideos?: MediaFrontmatter): IGatsbyImageData | null => {
-  const firstImage = getImages(imagesAndVideos)[0];
-  return firstImage ? getImage(firstImage.image) ?? null : null;
+export const getVideos = (rawMedia?: MediaFrontmatter): RawVideoData[] => {
+    return rawMedia?.videos || [];
+};
+
+export const getThumbnail = (
+    imagesAndVideos?: MediaFrontmatter,
+): ImageSource | null => {
+    const firstImage = getImages(imagesAndVideos)[0];
+    if (!firstImage) return null;
+    if (isCloudinaryUrl(firstImage.image)) return firstImage.image;
+    return getImage(firstImage.image) ?? null;
 };

--- a/static/admin/config.yml
+++ b/static/admin/config.yml
@@ -34,7 +34,7 @@ richTextFields: &richTextFields
           - { label: "Text", name: "text", widget: "string" }
           - { label: "URL", name: "url", widget: "string" }
 
-field_image: &field_image { label: "Image", name: "image", widget: "image" }
+field_image: &field_image { label: "Image", name: "image", widget: "cloudinary-image" }
 field_caption:
     &field_caption {
         label: "Caption",
@@ -93,7 +93,7 @@ header: &header
     - {
           label: "Background Image",
           name: "background",
-          widget: "image",
+          widget: "cloudinary-image",
           required: false,
       }
 
@@ -571,7 +571,7 @@ collections:
                                     {
                                         label: "Image",
                                         name: "image",
-                                        widget: "image",
+                                        widget: "cloudinary-image",
                                     },
                                     {
                                         label: "Caption",


### PR DESCRIPTION
Problem
=======
What is the problem this work solves, including
step 1 of #88 

Solution
========
What I/we did to solve this problem
- added a custom widget that opens the cloudinary upload widget , auto-derives upload folders from the cms entry. 
    - one folder per cell line, e.g. cell-lines/AICS-{id}-{clone}
    - on successful upload, the widget stores the cloudinary img url into markdown frontmatter image field
- created a shared component `ImageRenderer` to handle both gastby images(`GatsbyImage`) and external urls (`<img>`) 
- added `image_url` field via `createResolvers` in gatsby-node.js.
    - for a local image, `image` resolves to `GatsbyImage`, `image_url` is null
    - for cloudinary image urls, `image` is null and `image_url` carries the url 

Notes: 
This is mainly to show how Cloudinary can work with our current image management. With this change, images can now be uploaded to Cloudinary, while local images rendering still works the same as it does on `main`. 

Things we can decide separately later: 
- whether porting the existing local images in this repo to cloud storage 
- in idea-board, implement a similar upload flow if we want to move forward with cloud image storage 

Not yet implemented:
- removing images from Cloudinary folders, except through the Cloudinary UI


## Type of change
Please delete options that are not relevant.

* New feature (non-breaking change which adds functionality)


Steps to Verify:
----------------
- [x] [preview](https://deploy-preview-428--cell-catalog.netlify.app/)
- [x] [admin preview](https://deploy-preview-428--cell-catalog.netlify.app/admin)

1. on admin page, edit a cell line entry and use the new image upload widget 
2. cloudinary upload widget should open and upload to the correct folder, [link to gallery](https://console.cloudinary.com/app/c-e8d2b9288c2a191700bbe747f96a15/assets/media_library/folders/home?view_mode=mosaic) (lmk if you have any issues opening or viewing)
3. all images on the site should be rendered 

Screenshots (optional):
-----------------------
Show-n-tell images/animations here

- in Cloudinary, images are stored in designated folder structure
<img width="800" height="400" alt="Screenshot 2026-04-07 at 2 51 54 PM" src="https://github.com/user-attachments/assets/129b36f7-7eb1-4ffb-851f-296088c18c0f" />

- on the admin page, users can upload images to the cell line folder in Cloudinary. Local image preview remains unchanged. 
<img width="500" height="400" alt="Screenshot 2026-04-07 at 2 59 36 PM" src="https://github.com/user-attachments/assets/282a8c7f-fcff-48c6-a652-bb17d7fd836f" />

- but if clicks on `Replace Image` for a local image, the replacement image is uploaded to Cloudinary instead.   
<img width="500" height="400" alt="Screenshot 2026-04-07 at 3 22 51 PM" src="https://github.com/user-attachments/assets/e82fd8fd-4f8d-4436-a378-8464294ca8fe" />


